### PR TITLE
Tag support for tooltip allowing some tooltips to immediately be opened

### DIFF
--- a/v1-migration-folder/packages/react-components/src/tooltip/__tests__/tooltip.stories.tsx
+++ b/v1-migration-folder/packages/react-components/src/tooltip/__tests__/tooltip.stories.tsx
@@ -287,3 +287,63 @@ export const Api: StoryObj = {
     await userEvent.click(c.getByText("Explain more"));
   },
 };
+
+function TaggedComp() {
+  const t1 = useTooltip({
+    id: "1",
+    render: <div>Tooltip 1</div>,
+    tag: "alpha",
+    hideDelay: 100,
+  });
+  const t2 = useTooltip({
+    id: "2",
+    render: <div>Tooltip 2</div>,
+    tag: "alpha",
+    showDelay: 1000,
+    hideDelay: 500,
+  });
+  const t3 = useTooltip({
+    id: "3",
+    render: <div>Tooltip 2</div>,
+    showDelay: 1000,
+    hideDelay: 500,
+  });
+
+  return (
+    <>
+      <TooltipDriver />
+      <div
+        style={{
+          width: 200,
+          height: 200,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div {...t1} style={{ border: "1px solid black" }}>
+          Tag 1
+        </div>
+        <div {...t2} style={{ border: "1px solid black" }}>
+          Tag 2
+        </div>
+        <div {...t3} style={{ border: "1px solid black" }}>
+          Tag 3
+        </div>
+      </div>
+    </>
+  );
+}
+
+export const Tagged: StoryObj = {
+  render: TaggedComp,
+  play: async ({ canvas: c }) => {
+    await userEvent.hover(c.getByText("Tag 1"));
+    await sleep(20);
+    await userEvent.unhover(c.getByText("Tag 1"));
+    await sleep(20);
+    await userEvent.hover(c.getByText("Tag 2"));
+    await sleep(20);
+    await userEvent.unhover(c.getByText("Tag 2"));
+  },
+};

--- a/v1-migration-folder/packages/react-components/src/tooltip/tooltip-api.tsx
+++ b/v1-migration-folder/packages/react-components/src/tooltip/tooltip-api.tsx
@@ -27,6 +27,16 @@ function removeTooltip(id: string) {
   });
 }
 
+function hasOpenTag(tag: string) {
+  return getTooltipsWithTag(tag).length > 0;
+}
+function getTooltipsWithTag(tag: string) {
+  const store = getDefaultStore();
+  const tools = [...store.get(tooltips).values()];
+
+  return tools.filter((c) => c.tag === tag);
+}
+
 export const show = (c: Tooltip) => {
   const store = getDefaultStore();
 
@@ -39,6 +49,10 @@ export const show = (c: Tooltip) => {
   if (current.has(c.id)) {
     updateTooltip(c);
     return;
+  } else if (c.tag && hasOpenTag(c.tag)) {
+    const others = getTooltipsWithTag(c.tag);
+    others.forEach((c) => hide(c.id, true));
+    updateTooltip(c);
   }
 
   // Since the tooltip is not open, we begin the process of updating it. If there was already an


### PR DESCRIPTION
Tooltip tags allows the open state of tooltips to be linked together, such that if a tooltip with the given tag is already open then the other tooltips may be immediately opened.