### PR TITLE
Fixed safari desktop style repaint.

### DIFF
--- a/.changeset/itchy-jokes-itch.md
+++ b/.changeset/itchy-jokes-itch.md
@@ -1,0 +1,5 @@
+---
+"@1771technologies/lytenyte-core": patch
+---
+
+Fixed Safari Desktop style recalc for hover highlight.

--- a/grid-core/lytenyte-core/src/row-hover-driver/row-hover-driver.tsx
+++ b/grid-core/lytenyte-core/src/row-hover-driver/row-hover-driver.tsx
@@ -1,23 +1,33 @@
+import { useEffect } from "react";
 import { useGrid } from "../use-grid";
 
 export function RowHoverDriver() {
   const s = useGrid();
-  const gridId = s.state.gridId.use();
+  const grid = s.state.internal.viewport.use();
 
   const hoveredRow = s.state.internal.hoveredRow.use();
 
+  useEffect(() => {
+    if (hoveredRow == null || !grid) return;
+
+    const cells = Array.from(
+      grid.querySelectorAll(`div > div > .lng1771-cell[aria-rowindex="${hoveredRow + 1}"]`),
+    ) as HTMLElement[];
+
+    cells.forEach((c) => {
+      if (c.classList.contains(".lng1771-cell--selected"))
+        c.style.backgroundColor = "var(--lng1771-primary-30)";
+      else c.style.backgroundColor = "var(--lng1771-gray-10)";
+    });
+
+    return () => {
+      cells.forEach((c) => {
+        c.style.removeProperty("background-color");
+      });
+    };
+  }, [grid, hoveredRow]);
+
   if (hoveredRow == null) return;
 
-  return (
-    <style>
-      {`
-      #${gridId} > div > div > :not(.lng1771-cell--selected)[aria-rowindex="${hoveredRow + 1}"] {
-        background-color: var(--lng1771-gray-10);
-      }
-      #${gridId} > div > div > .lng1771-cell--selected[aria-rowindex="${hoveredRow + 1}"] {
-        background-color: var(--lng1771-primary-30);
-      }
-  `}
-    </style>
-  );
+  return <></>;
 }


### PR DESCRIPTION
Safari Desktop repaints the entire grid when the hover highlight style element changes. This results in frames being dropped by the hover highlight. 

This code changes so that we directly add the styles to the cell and remove them when the hover highlight is no longer present. This avoids the Safari repaints.