### PR TITLE
Fix multi sort direction on docs

### DIFF
--- a/documentation/examples/(row)/row-sorting-multi/src/demo.tsx
+++ b/documentation/examples/(row)/row-sorting-multi/src/demo.tsx
@@ -137,8 +137,19 @@ function Header({ column, grid }: HeaderCellRendererParams<BankData>) {
           } else {
             sort = { columnId, sort: { kind: "string" } };
           }
-        } else if (!current.sort.isDescending) {
-          sort = { ...current.sort, isDescending: true };
+        } else {
+          // If additive, we allow the current sort direction to continuously flip direction rather than being removed
+          if (isAdditive) {
+            sort = {
+              ...current.sort,
+              isDescending: !current.sort.isDescending,
+            };
+          } else if (!current.sort.isDescending) {
+            sort = {
+              ...current.sort,
+              isDescending: true,
+            };
+          }
         }
 
         if (isAdditive) {


### PR DESCRIPTION
Current behaviour:

On the row mutli sort docs, if I continuously add a multi sort to the same column, it will get stuck on desc. I would expect it to either flip, or be removed.

https://www.1771technologies.com/docs/row-sorting

Change explained:

If the mode is addititive, allow the current sort to flip from asc -> desc -> asc ... - with no hard limit for it to be strictly set to desc.


**Note**
This still permits a column sort to be removed if the additive key is not pressed