### PR TITLE
Update mutli-sort docs to reflect demo

### DIFF
--- a/documentation/content/docs/(row)/demos/row-sorting-multi/demo.tsx
+++ b/documentation/content/docs/(row)/demos/row-sorting-multi/demo.tsx
@@ -137,8 +137,19 @@ function Header({ column, grid }: HeaderCellRendererParams<BankData>) {
           } else {
             sort = { columnId, sort: { kind: "string" } };
           }
-        } else if (!current.sort.isDescending) {
-          sort = { ...current.sort, isDescending: true };
+        } else {
+          // If additive, we allow the current sort direction to continuously flip direction rather than being removed
+          if (isAdditive) {
+            sort = {
+              ...current.sort,
+              isDescending: !current.sort.isDescending,
+            };
+          } else if (!current.sort.isDescending) {
+            sort = {
+              ...current.sort,
+              isDescending: true,
+            };
+          }
         }
 
         if (isAdditive) {

--- a/documentation/examples/(row)/row-sorting-multi/src/demo.tsx
+++ b/documentation/examples/(row)/row-sorting-multi/src/demo.tsx
@@ -137,8 +137,19 @@ function Header({ column, grid }: HeaderCellRendererParams<BankData>) {
           } else {
             sort = { columnId, sort: { kind: "string" } };
           }
-        } else if (!current.sort.isDescending) {
-          sort = { ...current.sort, isDescending: true };
+        } else {
+          // If additive, we allow the current sort direction to continuously flip direction rather than being removed
+          if (isAdditive) {
+            sort = {
+              ...current.sort,
+              isDescending: !current.sort.isDescending,
+            };
+          } else if (!current.sort.isDescending) {
+            sort = {
+              ...current.sort,
+              isDescending: true,
+            };
+          }
         }
 
         if (isAdditive) {


### PR DESCRIPTION
Realised that I didn't update the demo code that is shown on the docs page.

The code powering the demo grid is different from the code that opens when you hit 'Show code'

<img width="138" height="39" alt="image" src="https://github.com/user-attachments/assets/ed4e9c70-dc1a-4b3d-b76f-b96c59a47aed" />

I guess you guys may be changing this with your docs update but didn't want it to be inconsistent.

Also, I think the original PR: https://github.com/1771-Technologies/lytenyte/pull/235 may have been reverted in this PR: https://github.com/1771-Technologies/lytenyte/pull/237 

If I'm missing any context, feel free to close this PR.