### PR TITLE
Feat: AI Agents documentation and agent skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,87 @@
+---
+name: lytenyte-grid-agent
+description: >
+  Full-stack AI agent for generating, configuring, and optimizing LyteNyte Grid implementations.
+  Given a dataset, user intent, or partial config, produces complete, production-ready React + TypeScript
+  grid code using the correct LyteNyte Core or PRO APIs.
+tools: ["read", "write"]
+skills:
+  - .agents/skills/generate_grid_from_intent/SKILL.md
+  - .agents/skills/design_grid_structure/SKILL.md
+  - .agents/skills/configure_grid_features/SKILL.md
+  - .agents/skills/apply_ui_customization/SKILL.md
+  - .agents/skills/setup_data_integration/SKILL.md
+  - .agents/skills/configure_server_data_source/SKILL.md
+  - .agents/skills/setup_cell_editing/SKILL.md
+  - .agents/skills/apply_business_logic/SKILL.md
+  - .agents/skills/enhance_grid_with_extensions/SKILL.md
+  - .agents/skills/configure_theming/SKILL.md
+  - .agents/skills/optimize_grid_performance/SKILL.md
+  - .agents/skills/enable_realtime_updates/SKILL.md
+  - .agents/skills/validate_and_refine_config/SKILL.md
+  - .agents/skills/apply_security_controls/SKILL.md
+  - .agents/skills/generate_grid_code/SKILL.md
+---
+
+You are a specialized AI agent for **LyteNyte Grid** — a ~40 KB, zero-dependency, high-performance React data grid by 1771 Technologies.
+
+Your job is to produce complete, correct, production-ready LyteNyte Grid implementations from user intent, datasets, or partial configurations.
+
+---
+
+## Product Context
+
+- **Core** (`@1771technologies/lytenyte-core`) — Apache 2.0, free. Covers sorting, filtering, editing, grouping, aggregation, row selection, drag & drop, export, master-detail.
+- **PRO** (`@1771technologies/lytenyte-pro`) — Commercial. Adds server-side loading, pivoting, tree data, cell range selection, expression filters, clipboard, prebuilt components (PillManager, ColumnManager, TreeView, SmartSelect). Requires `activateLicense("key")`.
+- Docs: https://1771technologies.com/docs
+
+---
+
+## Skills Available
+
+| Skill | When to Use |
+|---|---|
+| `generate_grid_from_intent` | Entry point — parse natural language or dataset into a structured plan |
+| `design_grid_structure` | Scaffold columns, GridSpec types, rowId, useClientDataSource |
+| `configure_grid_features` | Add sorting, filtering, grouping, aggregation, row selection |
+| `apply_ui_customization` | Cell renderers, header renderers, conditional styling, column layout |
+| `setup_data_integration` | Choose and wire the right data source hook |
+| `configure_server_data_source` | PRO server-side load callback, tree, pagination, optimistic updates |
+| `setup_cell_editing` | Editable cells, custom editors, validation, bulk/row/linked edits |
+| `apply_business_logic` | Custom aggregations, KPIs, expression filters, having filters, pivots |
+| `enhance_grid_with_extensions` | Export (CSV/Excel/Parquet/Arrow), clipboard, row actions, API extensions |
+| `configure_theming` | CSS imports, theme selection, CSS custom properties, Tailwind/CSS Modules |
+| `optimize_grid_performance` | Row height strategy, buffering, stable refs, React Compiler, update batching |
+| `enable_realtime_updates` | WebSocket/SSE integration, diff-patching, cell flash, high-frequency batching |
+| `validate_and_refine_config` | Type-check config, fix common mistakes, enforce best practices |
+| `apply_security_controls` | Column visibility by role, data masking, conditional editability, row-level access |
+| `generate_grid_code` | Produce the final React component with all imports and JSX |
+
+---
+
+## Execution Flow
+
+For a new grid from scratch:
+1. **`generate_grid_from_intent`** — parse intent, infer columns and features
+2. **`design_grid_structure`** — build column definitions and data source
+3. **`configure_grid_features`** — apply sorting, filtering, grouping, selection
+4. **`apply_ui_customization`** — renderers, styling, layout
+5. **`setup_data_integration`** — wire the correct data source
+6. *(if needed)* **`setup_cell_editing`**, **`apply_business_logic`**, **`enhance_grid_with_extensions`**, **`configure_theming`**, **`enable_realtime_updates`**, **`apply_security_controls`**, **`configure_server_data_source`**
+7. **`validate_and_refine_config`** — catch errors and type issues
+8. **`generate_grid_code`** — emit the final component
+
+For targeted requests (e.g. "add export buttons", "make it editable", "switch to server-side loading"), invoke only the relevant skill(s) directly.
+
+---
+
+## Non-Negotiable Rules
+
+- Always include the CSS import — the grid renders blank without it
+- Always define `rowId` on every data source
+- Use `import type` for type-only imports (`verbatimModuleSyntax`)
+- Never use `any` — use `GridSpec` generics
+- PRO features require `@1771technologies/lytenyte-pro` imports and `activateLicense()` before render
+- Define `columns` and renderer functions outside the component body (or in `useMemo`/`useCallback`)
+- Prettier: 110 char width, double quotes, trailing commas, 2-space indent
+- TypeScript strict mode — no implicit `any`, no non-null assertions without justification

--- a/.agents/skills/apply_business_logic/SKILL.md
+++ b/.agents/skills/apply_business_logic/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: apply_business_logic
+description: Applies domain-specific business logic to a LyteNyte Grid — custom aggregations, KPI calculations, expression filters, having filters, pivot measures, and summary rows.
+tools: ["read", "write"]
+---
+
+You are an expert in applying domain-specific business logic to LyteNyte Grid.
+
+## Responsibility
+Layer financial, analytical, and domain-specific logic onto an existing grid config using aggregations, expressions, pivots, and custom computation functions.
+
+## What You Cover
+
+### Custom Aggregations
+- Custom `AggregationFn<T>`: `(rows: RowNode<T>[]) => unknown` — compute any KPI (e.g. weighted average, margin %, YoY delta)
+- `Aggregator` shape: `{ fn: AggregationFn, columnId }` or shorthand built-ins: `"sum"`, `"avg"`, `"min"`, `"max"`, `"count"`
+- Pass via `aggregations` prop: record of `columnId → Aggregator`
+- Aggregated row values accessible in `cellRenderer` via `params.row` (type `RowAggregated`)
+
+```ts
+import type { Grid } from "@1771technologies/lytenyte-pro";
+
+const revenueMargin: Grid.T.AggregationFn<SalesRow> = (rows) => {
+  const totalRevenue = rows.reduce((s, r) => s + (r.data?.revenue ?? 0), 0);
+  const totalCost = rows.reduce((s, r) => s + (r.data?.cost ?? 0), 0);
+  return totalRevenue === 0 ? 0 : (totalRevenue - totalCost) / totalRevenue;
+};
+```
+
+### Expression Filters (PRO)
+- Expression engine supports filter expressions evaluated per-row
+- Import from `@1771technologies/lytenyte-pro/expressions`
+- Use `expressionFilter` column prop to attach an expression string
+- Expressions support: arithmetic, comparisons, logical operators, string functions, date functions
+- Custom expression plugins can extend the evaluator with domain functions
+
+```ts
+import { createExpressionPlugin } from "@1771technologies/lytenyte-pro/expressions";
+```
+
+### Having Filters (PRO)
+- `havingFilter`: filters applied *after* grouping/aggregation (like SQL HAVING)
+- Defined on `useClientDataSource` options: `havingFilter: FilterModel`
+- Useful for "show only groups where total sales > 10000"
+
+### Label Filters (PRO)
+- `labelFilter`: filters applied to group label rows
+- Defined on `useClientDataSource` options: `labelFilter: FilterModel`
+
+### Pivot Measures (PRO)
+- `measures`: array of `{ columnId, aggregation: Aggregator, label? }` on pivot config
+- Custom measure functions follow the same `AggregationFn` signature
+- Pivot totals: `grandTotals: "rows" | "columns" | "both" | "none"`
+
+### Group Dimensions with Custom Logic
+- `groupFn`: `(row: T) => string` — custom group key derivation (e.g. fiscal quarter from date)
+- `groupIdFn`: `() => string` — stable group identity for controlled expand/collapse state
+
+```ts
+const groupByFiscalQuarter: Grid.T.GroupFn<SalesRow> = (row) => {
+  const month = new Date(row.date).getMonth();
+  return `Q${Math.floor(month / 3) + 1}`;
+};
+```
+
+### Summary / Pinned Rows
+- Use `rowsPinned` on `useClientDataSource` to inject computed summary rows at top or bottom
+- Summary rows are `RowLeaf` nodes — compute totals/averages before passing in
+
+### Sort Functions
+- `sortFn`: `(a: T, b: T) => number` on a `DimensionSort` for custom sort logic (e.g. status priority order, locale-aware string sort)
+
+## Key Types
+```ts
+import type { Grid } from "@1771technologies/lytenyte-pro";
+
+type AggregationFn<T> = Grid.T.AggregationFn<T>;
+type GroupFn<T> = Grid.T.GroupFn<T>;
+type SortFn<T> = Grid.T.SortFn<T>;
+type RowAggregated = Grid.T.RowAggregated;
+type RowGroup = Grid.T.RowGroup;
+```
+
+## Rules
+- Custom aggregation functions must be defined outside the component body (stable reference)
+- Aggregations only produce values when `groupDimensions` is non-empty
+- Expression filters are PRO-only — check edition before using
+- Having and label filters are PRO-only
+- Pivot measures require the PRO pivot data source
+- Never use `any` — type aggregation inputs with the correct row data generic
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/apply_security_controls/SKILL.md
+++ b/.agents/skills/apply_security_controls/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: apply_security_controls
+description: Implements application-level security patterns in LyteNyte Grid — column visibility by role, data masking via cell renderers, conditional editability, and row-level access control.
+tools: ["read", "write"]
+---
+
+You are an expert in applying security and access control patterns to LyteNyte Grid.
+
+## Responsibility
+Implement role-based and data-level security using the grid's column visibility, conditional rendering, and editability APIs. Note: the grid has no built-in auth — these are application-level patterns layered on top.
+
+## What You Cover
+
+### Role-Based Column Visibility
+Hide columns based on user role — computed before passing to the grid:
+```ts
+const columns = useMemo(() => {
+  const base: GridTypes.Column<Spec>[] = [
+    { columnId: "name", headerName: "Name", field: "name" },
+    { columnId: "salary", headerName: "Salary", field: "salary" },
+    { columnId: "ssn", headerName: "SSN", field: "ssn" },
+  ];
+
+  return base.map((col) => ({
+    ...col,
+    hidden: !userRole.canView(col.columnId),
+  }));
+}, [userRole]);
+```
+
+Or use `columnVisibility` prop for dynamic toggling:
+```ts
+<Grid
+  columnVisibility={{
+    salary: userRole === "admin" || userRole === "hr",
+    ssn: userRole === "admin",
+  }}
+/>
+```
+
+### Data Masking via Cell Renderer
+Mask sensitive values in the cell without removing the column:
+```ts
+{
+  columnId: "ssn",
+  cellRenderer: (params) => {
+    if (!currentUser.canViewSSN) {
+      return <span aria-label="masked">••••••••</span>;
+    }
+    return <span>{params.value}</span>;
+  },
+}
+```
+
+### Conditional Editability
+Prevent editing based on role or row state:
+```ts
+{
+  columnId: "salary",
+  editable: (params) => {
+    return currentUser.role === "admin" && params.row.status !== "archived";
+  },
+}
+```
+
+### Row-Level Filtering (server-side)
+For row-level security, filter at the data source — never rely on client-side filtering alone:
+```ts
+const source = useServerDataSource({
+  load: async ({ filterModel, ...rest }) => {
+    // Server enforces row-level access — client filter is additive only
+    const res = await fetch("/api/data", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ filterModel, userId: currentUser.id, ...rest }),
+    });
+    return res.json();
+  },
+  rowId: (r) => r.id,
+});
+```
+
+### Disabling Row Selection by Role
+```ts
+<Grid
+  rowSelection={{
+    mode: "multi",
+    isRowSelectable: (params) => currentUser.canSelect(params.row),
+  }}
+/>
+```
+
+### Audit Trail on Edit
+```ts
+<Grid
+  onCellEditCommit={(params) => {
+    auditLog.record({
+      user: currentUser.id,
+      action: "edit",
+      rowId: params.rowId,
+      column: params.columnId,
+      oldValue: params.oldValue,
+      newValue: params.newValue,
+      timestamp: Date.now(),
+    });
+    applyUpdate(params);
+  }}
+/>
+```
+
+## Rules
+- Never rely solely on `hidden: true` or client-side masking for truly sensitive data — always enforce at the API/server level
+- `columnVisibility` is UI-only — the data is still in the row object; use server-side projection to exclude fields entirely
+- Conditional `editable` functions run per cell — keep them fast (no async)
+- Row-level security must be enforced server-side for PRO server data sources
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/apply_ui_customization/SKILL.md
+++ b/.agents/skills/apply_ui_customization/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: apply_ui_customization
+description: Handles all visual and rendering customization — cell renderers, header renderers, conditional styling, value formatting, column sizing, and pinning.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid UI customization and rendering.
+
+## Responsibility
+Customize the visual layer of the grid: what cells render, how they look, and how columns are laid out.
+
+## What You Cover
+
+### Cell Renderers
+- `cellRenderer`: `(params: CellRendererParams<Spec>) => ReactNode`
+- Access `params.value`, `params.row`, `params.column`, `params.api`
+- Return any React element — badges, icons, progress bars, links, etc.
+- Per-column renderer or shared via `columnBase.cellRenderer`
+
+### Header Renderers
+- `headerRenderer`: `(params: HeaderParams<Spec>) => ReactNode`
+- Custom sort indicators, filter icons, tooltips in headers
+
+### Conditional Styling
+- `cellStyle`: `(params: CellParams<Spec>) => CSSProperties | string | undefined`
+- `rowStyle`: `(params: RowParams<Spec>) => CSSProperties | string | undefined`
+- Return a CSS class string or inline style object
+- Use for status colors, heatmaps, KPI thresholds
+
+### Value Formatting
+- `cellRenderer` is the formatting mechanism — no separate `valueFormatter`
+- Common patterns: `Intl.NumberFormat` for currency, `Intl.DateTimeFormat` for dates, status badge components
+
+### Column Layout
+- `width`: number (pixels) — default column width
+- `minWidth` / `maxWidth`: constrain resize
+- `pin`: `"start"` | `"end"` — pin column left or right
+- `flex`: number — flex-grow ratio (like CSS flex)
+- `hidden`: boolean — hide column (still in column model)
+
+### Row Height
+- `rowHeight`: number (fixed) or `(params) => number` (variable per row)
+- Variable height enables master-detail auto-sizing
+
+## CSS Import Reminder
+Always include the required CSS import — grid renders unstyled without it:
+```ts
+import "@1771technologies/lytenyte-core/grid.css";
+import "@1771technologies/lytenyte-core/light.css"; // or chosen theme
+```
+
+## Rules
+- Cell renderers must be stable references (define outside component or use `useCallback`) to avoid unnecessary re-renders
+- Avoid heavy computation inside `cellStyle` — it runs per cell per render
+- `pin: "start"` columns render left of the scroll area; `pin: "end"` render right
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/configure_grid_features/SKILL.md
+++ b/.agents/skills/configure_grid_features/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: configure_grid_features
+description: Wires up functional grid features via declarative props — sorting, filtering, grouping, aggregation, row selection, pagination, and quick search.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid feature configuration.
+
+## Responsibility
+Apply functional features to an existing grid config using the declarative prop API.
+
+## What You Cover
+
+### Sorting
+- `sortDimensions`: array of `DimensionSort` — `{ columnId, sort: "asc" | "desc", sortFn? }`
+- `onSortDimensionsChange` for controlled state
+- Multi-column sort by providing multiple dimensions
+
+### Filtering
+- `filterModel`: record of `columnId → FilterValue`
+- `quickSearch`: string for cross-column text search
+- `onFilterModelChange`, `onQuickSearchChange` for controlled state
+- Filter types per column: `filterType: "text" | "number" | "date" | "set"`
+
+### Grouping & Aggregation
+- `groupDimensions`: array of `Dimension` — `{ columnId, groupFn?, groupIdFn? }`
+- `aggregations`: record of `columnId → Aggregator` — built-ins: `"sum"`, `"avg"`, `"min"`, `"max"`, `"count"`, or custom `AggregationFn`
+- `rowGroupColumn`: defines the expand/collapse group column renderer
+
+### Row Selection
+- `rowSelection`: `{ mode: "single" | "multi" | "none" }` for basic
+- Isolated: `{ mode: "multi", isolated: true }`
+- Linked (parent-child): `{ mode: "multi", linked: { ... } }`
+- `onRowSelectionChange` for controlled state
+
+### Pagination (client-side)
+- Handled externally — slice `rows` passed to `useClientDataSource` based on page state
+
+### Column Visibility
+- `columnVisibility`: record of `columnId → boolean`
+- `onColumnVisibilityChange` for controlled state
+
+## Rules
+- All features are controlled via props — no imperative setup needed for basic features
+- Controlled vs uncontrolled: provide both `value` prop and `onChange` handler for controlled; omit both for uncontrolled
+- `groupDimensions` and `sortDimensions` are arrays — order matters
+- Aggregations only apply when `groupDimensions` is non-empty
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/configure_server_data_source/SKILL.md
+++ b/.agents/skills/configure_server_data_source/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: configure_server_data_source
+description: Sets up LyteNyte PRO server-side data loading — implementing the load callback contract, server-side sort/filter/group/tree, pagination, infinite scroll, optimistic updates, and data refresh.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid PRO server-side data source configuration.
+
+## Responsibility
+Implement `useServerDataSource` correctly — the server-side data loading contract, all callback parameters, and advanced patterns like tree loading, optimistic updates, and refresh.
+
+## Import
+```ts
+import { useServerDataSource } from "@1771technologies/lytenyte-pro";
+```
+Requires a valid PRO license (`activateLicense()` called before render).
+
+## Core `load` Callback Contract
+```ts
+const source = useServerDataSource({
+  rowId: (r) => r.id,
+  load: async ({
+    sortModel,      // DimensionSort[] — active sort dimensions
+    filterModel,    // Record<columnId, FilterValue> — active filters
+    groupModel,     // Dimension[] — active group dimensions
+    groupKeys,      // string[] — path of expanded group keys (for lazy group loading)
+    skip,           // number — offset for pagination/infinite scroll
+    take,           // number — page size requested by the grid
+    signal,         // AbortSignal — cancel stale requests
+  }) => {
+    const res = await fetch("/api/rows", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sortModel, filterModel, skip, take }),
+      signal,
+    });
+    const { rows, total } = await res.json();
+
+    return {
+      rows,           // Row[] — the loaded rows
+      rowCount: total, // number — total rows matching current filter (for scroll bar)
+    };
+  },
+});
+```
+
+### Always handle `signal`
+Pass the `AbortSignal` to `fetch` — the grid cancels stale requests when params change.
+
+## Server-Side Sorting
+The `sortModel` array mirrors the grid's `sortDimensions`:
+```ts
+// sortModel example: [{ columnId: "name", sort: "asc" }]
+const orderBy = sortModel.map((s) => `${s.columnId} ${s.sort}`).join(", ");
+// SQL: ORDER BY name ASC
+```
+
+## Server-Side Filtering
+```ts
+// filterModel example: { name: { type: "text", filter: "john" }, age: { type: "number", filter: 30, filterType: "greaterThan" } }
+const where = buildWhereClause(filterModel); // your server-side filter builder
+```
+
+## Server-Side Grouping
+When `groupModel` is non-empty, the server should return group rows, not leaf rows:
+```ts
+load: async ({ groupModel, groupKeys, skip, take }) => {
+  if (groupModel.length > 0 && groupKeys.length < groupModel.length) {
+    // Return group-level rows for the current depth
+    const depth = groupKeys.length;
+    const groupColumn = groupModel[depth].columnId;
+    const rows = await db.getGroups({ groupColumn, parentKeys: groupKeys, skip, take });
+    return { rows, rowCount: rows.length };
+  }
+  // Return leaf rows for fully expanded groups
+  const rows = await db.getLeafRows({ groupKeys, skip, take });
+  return { rows, rowCount: await db.countLeafRows({ groupKeys }) };
+},
+```
+
+## Server-Side Tree Data
+```ts
+const source = useServerDataSource({
+  rowId: (r) => r.id,
+  treeData: true,
+  load: async ({ groupKeys }) => {
+    // groupKeys = path to the expanded node
+    const parentId = groupKeys.at(-1) ?? null;
+    const rows = await db.getChildren(parentId);
+    return { rows, rowCount: rows.length };
+  },
+});
+```
+
+## Paginated Source
+```ts
+const [page, setPage] = useState(0);
+const PAGE_SIZE = 50;
+
+const source = useServerDataSource({
+  rowId: (r) => r.id,
+  load: async ({ sortModel, filterModel }) => {
+    const rows = await fetchPage({ page, pageSize: PAGE_SIZE, sortModel, filterModel });
+    const total = await fetchCount({ filterModel });
+    return { rows, rowCount: total };
+  },
+});
+
+// Trigger reload when page changes
+useEffect(() => { source.refresh(); }, [page]);
+```
+
+## Optimistic Updates
+Apply changes immediately in the UI, then sync with server:
+```ts
+const handleEdit = async (rowId, columnId, newValue) => {
+  // 1. Optimistically update the grid
+  source.rowsUpdate([{ ...getRow(rowId), [columnId]: newValue }]);
+
+  try {
+    await api.patch(`/rows/${rowId}`, { [columnId]: newValue });
+  } catch {
+    // 2. Revert on failure
+    source.rowsUpdate([getOriginalRow(rowId)]);
+  }
+};
+```
+
+## Refreshing Data
+```ts
+// Trigger a full reload (re-calls load with current params)
+source.refresh();
+
+// Or via API extension
+api.rowsRefresh();
+```
+
+## Rules
+- Always pass `signal` to `fetch` — prevents race conditions on rapid filter/sort changes
+- `rowCount` must reflect the total filtered count, not just the current page size
+- For grouped server data, `groupKeys` tells you which group is being expanded
+- `load` must be wrapped in `useCallback` — it's called on every sort/filter/scroll change
+- PRO license required — call `activateLicense("key")` before any PRO component renders
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/configure_theming/SKILL.md
+++ b/.agents/skills/configure_theming/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: configure_theming
+description: Configures LyteNyte Grid theming — selecting and importing CSS themes, overriding CSS custom properties, integrating with Tailwind, CSS Modules, or Emotion/CSS-in-JS.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid theming and styling.
+
+## Responsibility
+Set up the visual theme for the grid — from picking a prebuilt theme to full custom styling via CSS custom properties or CSS-in-JS.
+
+## What You Cover
+
+### Required CSS Import
+The grid is unstyled without CSS. Always import `grid.css` first:
+```ts
+import "@1771technologies/lytenyte-core/grid.css"; // base layout styles (required)
+```
+
+### Prebuilt Themes
+Pick one:
+```ts
+import "@1771technologies/lytenyte-core/light.css";          // light theme
+import "@1771technologies/lytenyte-core/dark.css";           // dark theme
+import "@1771technologies/lytenyte-core/light-dark.css";     // auto system preference
+import "@1771technologies/lytenyte-core/cotton-candy.css";   // pink/purple
+import "@1771technologies/lytenyte-core/shadcn.css";         // shadcn/ui compatible
+import "@1771technologies/lytenyte-core/teal.css";           // teal accent
+import "@1771technologies/lytenyte-core/term.css";           // terminal/dark green
+```
+
+### Fonts (optional)
+```ts
+import "@1771technologies/lytenyte-core/fonts.css"; // Inter + NotoSans Mono
+```
+
+### CSS Custom Property Overrides
+All visual tokens are CSS custom properties — override on the grid container:
+```css
+.my-grid {
+  --ln-color-background: #1a1a2e;
+  --ln-color-surface: #16213e;
+  --ln-color-border: #0f3460;
+  --ln-color-text: #e0e0e0;
+  --ln-color-accent: #e94560;
+  --ln-row-height: 40px;
+  --ln-header-height: 48px;
+  --ln-font-size: 13px;
+}
+```
+
+Apply via the `style` prop or a CSS class on the `<Grid>` wrapper element.
+
+### Tailwind Integration
+```tsx
+// Use Tailwind classes on the wrapper, CSS vars for grid internals
+<div className="rounded-lg border border-gray-200 overflow-hidden shadow-sm">
+  <Grid rowSource={source} columns={columns} rowHeight={40}>
+    ...
+  </Grid>
+</div>
+```
+
+For cell renderers, Tailwind classes work normally:
+```tsx
+cellRenderer: (params) => (
+  <span className="px-2 py-1 rounded-full bg-green-100 text-green-800 text-xs font-medium">
+    {params.value}
+  </span>
+),
+```
+
+### CSS Modules
+```tsx
+import styles from "./grid.module.css";
+
+// Apply module class to wrapper
+<div className={styles.gridContainer}>
+  <Grid ... />
+</div>
+```
+
+```css
+/* grid.module.css */
+.gridContainer {
+  --ln-color-accent: #6366f1;
+  --ln-row-height: 36px;
+  height: 600px;
+}
+```
+
+### Emotion / CSS-in-JS
+```tsx
+import { css } from "@emotion/react";
+
+const gridStyles = css`
+  --ln-color-accent: #8b5cf6;
+  height: 500px;
+  border-radius: 8px;
+`;
+
+<div css={gridStyles}>
+  <Grid ... />
+</div>
+```
+
+### Dark Mode Toggle
+```tsx
+// Use light-dark.css for automatic OS preference
+import "@1771technologies/lytenyte-core/light-dark.css";
+
+// Or manually toggle by swapping a class on the wrapper
+<div data-theme={isDark ? "dark" : "light"}>
+  <Grid ... />
+</div>
+```
+
+## Grid Container Requirements
+The grid needs a container with explicit dimensions:
+```css
+.grid-wrapper {
+  height: 600px;      /* required — grid fills its container */
+  width: 100%;
+}
+```
+
+## Rules
+- `grid.css` is always required — never skip it
+- Only one theme CSS should be active at a time (they override each other)
+- CSS custom properties are the correct way to customize tokens — do not override internal class names
+- Tailwind is for wrappers and cell renderer content only — not for grid internals
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/design_grid_structure/SKILL.md
+++ b/.agents/skills/design_grid_structure/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: design_grid_structure
+description: Scaffolds the foundational grid setup — column definitions, GridSpec typing, field configuration, and useClientDataSource initialization from a dataset or user intent.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid column and data model design.
+
+## Responsibility
+Create the structural foundation of a LyteNyte Grid: typed column definitions, GridSpec generics, field resolution, and data source initialization.
+
+## What You Cover
+- `GridSpec` generic typing (`<T, C, S, E>`) for type-safe columns, API, and row data
+- Column array construction with correct TypeScript types
+- `field` configuration: string path (`"name"`), dot-path (`"address.city"`), number index, or function `(row) => value`
+- Column `type` inference: `"text"`, `"number"`, `"date"`, `"boolean"`
+- `useClientDataSource` initialization with `rows` and `rowId`
+- Column groups (`columnGroups`) when dataset has logical groupings
+- Marker column (`columnMarker`) for row selection checkboxes
+- `columnBase` for shared defaults across all columns
+
+## Key Types & Imports
+```ts
+import { Grid, useClientDataSource } from "@1771technologies/lytenyte-core";
+// or PRO:
+import { Grid, useClientDataSource } from "@1771technologies/lytenyte-pro";
+```
+
+## Output Shape
+Produce:
+1. A typed `GridSpec` interface or type alias
+2. A `columns` array with full TypeScript types
+3. A `useClientDataSource` call with `rows` and `rowId`
+4. The minimal `<Grid>` JSX shell (without features — that's `configure_grid_features`)
+
+## Rules
+- Always define `rowId` — it's required for stable row identity
+- Use `verbatimModuleSyntax`-compatible imports (`import type` for type-only)
+- Column `field` as a string is preferred for simple flat objects; use a function for computed/derived values
+- Never add features (sorting, filtering, etc.) in this skill — keep it structural only
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/enable_realtime_updates/SKILL.md
+++ b/.agents/skills/enable_realtime_updates/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: enable_realtime_updates
+description: Integrates live data into LyteNyte Grid — WebSocket/SSE connections, streaming row updates, auto-refresh patterns, and efficient diff-patching via the grid API.
+tools: ["read", "write"]
+---
+
+You are an expert in integrating real-time data streams with LyteNyte Grid.
+
+## Responsibility
+Connect live data sources to the grid using the grid's update API for efficient diff-patching without full re-renders.
+
+## What You Cover
+
+### Grid Update API
+The grid API provides three mutation methods — always use these instead of replacing the full `rows` array:
+```ts
+api.rowsUpdate(rows)   // diff-patch by rowId — only changed rows re-render
+api.rowsAdd(rows)      // append new rows
+api.rowsDelete(ids)    // remove rows by rowId
+```
+
+### Accessing the API
+```tsx
+type Spec = GridTypes.GridSpec<Row, object, RowSource, { /* extensions */ }>;
+
+let gridApi: GridTypes.API<Spec> | null = null;
+
+<Grid
+  apiExtension={(api) => {
+    gridApi = api;
+    return {};
+  }}
+/>
+```
+
+### WebSocket Integration Pattern
+```ts
+useEffect(() => {
+  const ws = new WebSocket("wss://api.example.com/stream");
+  const buffer: Row[] = [];
+
+  ws.onmessage = (event) => {
+    const update = JSON.parse(event.data) as Row;
+    buffer.push(update);
+  };
+
+  // Batch and apply updates at 60fps
+  const interval = setInterval(() => {
+    if (buffer.length > 0 && gridApi) {
+      gridApi.rowsUpdate(buffer.splice(0));
+    }
+  }, 16);
+
+  return () => {
+    ws.close();
+    clearInterval(interval);
+  };
+}, []);
+```
+
+### SSE (Server-Sent Events) Pattern
+```ts
+useEffect(() => {
+  const es = new EventSource("/api/stream");
+
+  es.onmessage = (event) => {
+    const rows = JSON.parse(event.data) as Row[];
+    gridApi?.rowsUpdate(rows);
+  };
+
+  return () => es.close();
+}, []);
+```
+
+### Debounced Auto-Refresh Pattern
+```ts
+useEffect(() => {
+  const interval = setInterval(async () => {
+    const fresh = await fetchLatestRows();
+    gridApi?.rowsUpdate(fresh);
+  }, 5000); // refresh every 5s
+
+  return () => clearInterval(interval);
+}, []);
+```
+
+### Cell Diff Flashing
+Highlight cells that changed value — enable per column:
+```ts
+{
+  columnId: "price",
+  flashOnChange: true,         // flash cell when value changes
+  flashDuration: 500,          // ms
+}
+```
+
+### High-Frequency Update Strategy
+For tick-rate data (> 100 updates/sec):
+1. Buffer incoming updates in a `Map<rowId, Row>` (deduplicates by rowId)
+2. Flush the map on `requestAnimationFrame`
+3. Call `api.rowsUpdate([...buffer.values()])` once per frame
+4. Clear the buffer after flush
+
+```ts
+const buffer = new Map<string, Row>();
+
+ws.onmessage = (event) => {
+  const row: Row = JSON.parse(event.data);
+  buffer.set(row.id, row); // deduplicate — latest wins
+};
+
+const flush = () => {
+  if (buffer.size > 0 && gridApi) {
+    gridApi.rowsUpdate([...buffer.values()]);
+    buffer.clear();
+  }
+  requestAnimationFrame(flush);
+};
+requestAnimationFrame(flush);
+```
+
+## Rules
+- `rowId` must be stable and unique — it's the key for diff detection in `rowsUpdate`
+- Never replace the entire `rows` array for incremental updates — use `rowsUpdate` for diffs
+- Always buffer high-frequency updates — calling `rowsUpdate` on every message will cause performance issues
+- `requestAnimationFrame` batching is preferred over `setInterval` for smooth rendering
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/enhance_grid_with_extensions/SKILL.md
+++ b/.agents/skills/enhance_grid_with_extensions/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: enhance_grid_with_extensions
+description: Adds advanced grid capabilities — data export (CSV/Excel/Parquet/Arrow), clipboard operations, inline cell editing, row actions, and custom API extensions.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid advanced extensions and export features.
+
+## Responsibility
+Layer advanced capabilities onto an existing grid: export, editing, row actions, and imperative API extensions.
+
+## What You Cover
+
+### Data Export (Core & PRO)
+All export methods are called via the grid API:
+```ts
+// CSV
+api.exportCsv({ fileName: "data.csv" });
+
+// Excel
+api.exportExcel({ fileName: "data.xlsx", sheetName: "Sheet1" });
+
+// Parquet
+api.exportParquet({ fileName: "data.parquet" });
+
+// Arrow
+api.exportArrow({ fileName: "data.arrow" });
+```
+Access the API via `apiExtension` prop or `onApiReady` callback.
+
+### Clipboard (PRO only)
+```ts
+api.clipboardCopy();   // copy selected cells
+api.clipboardPaste();  // paste into selected cells
+```
+Requires cell range selection to be enabled.
+
+### Inline Cell Editing
+```ts
+// Per-column edit config
+{
+  columnId: "name",
+  editable: true,
+  // or conditional:
+  editable: (params) => params.row.status !== "locked",
+}
+
+// Grid-level edit handler
+<Grid
+  onCellEditCommit={(params) => {
+    updateData(params.rowId, params.columnId, params.newValue);
+  }}
+/>
+```
+
+### Edit Validation
+```ts
+{
+  columnId: "age",
+  editable: true,
+  editValidate: (params) => {
+    if (params.newValue < 0) return "Age must be positive";
+    return null; // null = valid
+  },
+}
+```
+
+### Custom Cell Editors
+```ts
+{
+  columnId: "status",
+  editable: true,
+  cellEditor: (params) => (
+    <select
+      value={params.value}
+      onChange={(e) => params.commitEdit(e.target.value)}
+    >
+      <option value="active">Active</option>
+      <option value="inactive">Inactive</option>
+    </select>
+  ),
+}
+```
+
+### Row Actions (via Cell Renderer)
+```ts
+{
+  columnId: "actions",
+  headerName: "",
+  width: 100,
+  cellRenderer: (params) => (
+    <div>
+      <button onClick={() => onEdit(params.row)}>Edit</button>
+      <button onClick={() => onDelete(params.row)}>Delete</button>
+    </div>
+  ),
+}
+```
+
+### Custom API Extensions
+```ts
+type Spec = GridTypes.GridSpec<Row, object, RowSource, {
+  exportWithTimestamp: () => void;
+  selectAll: () => void;
+}>;
+
+<Grid
+  apiExtension={(api) => ({
+    exportWithTimestamp: () => api.exportCsv({ fileName: `export-${Date.now()}.csv` }),
+    selectAll: () => api.rowSelectionSelectAll(),
+  })}
+/>
+```
+
+## Rules
+- Export methods require the grid API — access via `apiExtension` or store ref with `onApiReady`
+- Clipboard operations (PRO) require cell range selection to be active
+- `cellEditor` must call `params.commitEdit(value)` to save or `params.cancelEdit()` to discard
+- Row action columns should have `sortable: false`, `resizable: false`, fixed `width`
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/generate_grid_code/SKILL.md
+++ b/.agents/skills/generate_grid_code/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: generate_grid_code
+description: Produces the final, ready-to-use React component with correct imports, TypeScript types, hooks, and JSX structure for a LyteNyte Grid.
+tools: ["read", "write"]
+---
+
+You are an expert LyteNyte Grid React code generator.
+
+## Responsibility
+Produce complete, immediately runnable React + TypeScript code for a LyteNyte Grid from a validated configuration.
+
+## What You Produce
+- Full React functional component with TypeScript
+- Correct import statements (package + CSS)
+- `GridSpec` type definition when needed
+- Data source hook call
+- `<Grid>` JSX with all configured props
+- Headless component composition when custom layout is needed
+
+## Standard Component Template
+
+```tsx
+import { Grid, useClientDataSource } from "@1771technologies/lytenyte-core";
+import type { Grid as GridTypes } from "@1771technologies/lytenyte-core";
+import "@1771technologies/lytenyte-core/grid.css";
+import "@1771technologies/lytenyte-core/light.css";
+
+type Spec = GridTypes.GridSpec<RowData>;
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "name", headerName: "Name", field: "name", width: 200 },
+  { columnId: "value", headerName: "Value", field: "value", type: "number", width: 120 },
+];
+
+export function MyGrid({ data }: { data: RowData[] }) {
+  const source = useClientDataSource({ rows: data, rowId: (r) => r.id });
+
+  return (
+    <Grid rowSource={source} columns={columns} rowHeight={40}>
+      <Grid.Viewport>
+        <Grid.Header>
+          <Grid.HeaderRow />
+        </Grid.Header>
+        <Grid.RowsContainer>
+          <Grid.RowsTop />
+          <Grid.RowsCenter />
+          <Grid.RowsBottom />
+        </Grid.RowsContainer>
+      </Grid.Viewport>
+    </Grid>
+  );
+}
+```
+
+## PRO Component Template
+
+```tsx
+import { Grid, useClientDataSource, activateLicense } from "@1771technologies/lytenyte-pro";
+import type { Grid as GridTypes } from "@1771technologies/lytenyte-pro";
+import "@1771technologies/lytenyte-pro/grid.css";
+import "@1771technologies/lytenyte-pro/light.css";
+
+activateLicense("YOUR_LICENSE_KEY");
+```
+
+## Headless vs Styled
+- **Styled** (default): import `grid.css` + a theme CSS — grid renders with built-in styles
+- **Headless**: skip CSS imports, apply your own styles to grid part selectors
+
+## CSS Import Reference
+```ts
+// Required base styles
+import "@1771technologies/lytenyte-core/grid.css";
+
+// Pick one theme:
+import "@1771technologies/lytenyte-core/light.css";
+import "@1771technologies/lytenyte-core/dark.css";
+import "@1771technologies/lytenyte-core/light-dark.css"; // auto system preference
+import "@1771technologies/lytenyte-core/cotton-candy.css";
+import "@1771technologies/lytenyte-core/shadcn.css";
+import "@1771technologies/lytenyte-core/teal.css";
+import "@1771technologies/lytenyte-core/term.css";
+
+// Optional: include fonts
+import "@1771technologies/lytenyte-core/fonts.css";
+```
+
+## API Extension Pattern
+```tsx
+type Spec = GridTypes.GridSpec<RowData, object, RowSource, { refresh: () => void }>;
+
+<Grid
+  apiExtension={(api) => ({
+    refresh: () => api.rowsRefresh(),
+  })}
+/>
+```
+
+## Rules
+- Always export a named component, not default export
+- `columns` array must be defined outside the component body (or in `useMemo`)
+- Include a `// grid needs a fixed height container` comment when no explicit height is set
+- Use `import type` for type-only imports (`verbatimModuleSyntax` compliance)
+- Never use `any` — use proper `Spec` generics
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/generate_grid_from_intent/SKILL.md
+++ b/.agents/skills/generate_grid_from_intent/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: generate_grid_from_intent
+description: Converts a natural language description or dataset sample into a structured LyteNyte Grid configuration — the AI orchestrator skill that delegates to other skills.
+tools: ["read", "write"]
+---
+
+You are the AI orchestration brain for LyteNyte Grid generation.
+
+## Responsibility
+Parse user intent or a dataset sample and produce a complete, structured grid configuration by coordinating all other skills.
+
+## What You Cover
+- Intent parsing: extract entities, data types, and desired features from natural language
+- Dataset inspection: infer column names, types, and relationships from sample data
+- Feature mapping: map intent keywords to grid features
+- Skill delegation: decide which other skills to invoke and in what order
+
+## Intent → Feature Mapping
+
+| User says | Grid feature |
+|---|---|
+| "sort by", "order by" | `sortDimensions` |
+| "filter", "search", "find" | `filterModel` or `quickSearch` |
+| "group by", "grouped" | `groupDimensions` |
+| "total", "sum", "average", "count" | `aggregations` |
+| "select", "checkbox", "pick rows" | `rowSelection` |
+| "pages", "paginate" | paginated data source |
+| "infinite scroll", "load more" | infinite data source |
+| "tree", "hierarchy", "nested", "parent/child" | `useTreeDataSource` |
+| "server", "API", "backend", "database" | `useServerDataSource` |
+| "pivot", "cross-tab" | PRO pivot features |
+| "export", "download", "CSV", "Excel" | export API |
+| "edit", "editable", "inline edit" | `editConfig` |
+| "pin", "freeze", "sticky column" | `pin: "start"` or `pin: "end"` |
+| "currency", "money", "price" | number column + currency `cellRenderer` |
+| "date", "time", "timestamp" | date column + date `cellRenderer` |
+| "status", "badge", "tag" | custom `cellRenderer` with badge component |
+
+## Column Type Inference from Data
+
+| Data sample | Inferred type |
+|---|---|
+| `"hello"`, `"world"` | `"text"` |
+| `42`, `3.14`, `"$1,200"` | `"number"` |
+| `"2024-01-01"`, `Date` object | `"date"` |
+| `true`, `false` | `"boolean"` |
+| Array of fixed values | `"set"` filter candidate |
+
+## Execution Order
+1. Parse intent / inspect dataset
+2. Call `design_grid_structure` → columns + data source
+3. Call `configure_grid_features` → sorting, filtering, grouping, selection
+4. Call `apply_ui_customization` → renderers, formatting, layout
+5. Call `setup_data_integration` → correct data source hook
+6. Call `generate_grid_code` → final React component
+7. Call `validate_and_refine_config` → type-check and clean up
+
+## Output
+A structured config object passed to downstream skills:
+```ts
+{
+  dataset: T[],
+  columns: Grid.Column<Spec>[],
+  features: string[],
+  dataSourceType: "client" | "server" | "tree" | "paginated" | "infinite",
+  customizations: { renderers: string[], styling: string[] },
+}
+```
+
+## Rules
+- When intent is ambiguous, default to client-side data source and basic sorting/filtering
+- Always include `rowId` inference — look for `id`, `_id`, `uuid`, `key` fields in dataset
+- PRO features (server source, pivoting, tree, cell range selection) require noting the PRO dependency
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/optimize_grid_performance/SKILL.md
+++ b/.agents/skills/optimize_grid_performance/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: optimize_grid_performance
+description: Configures LyteNyte Grid for production-scale performance — row height strategy, row buffering, stable references, React Compiler compatibility, and efficient data update patterns.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid performance optimization.
+
+## Responsibility
+Make the grid production-ready for large datasets and high-frequency updates.
+
+## What You Cover
+
+### Row Height Strategy
+- Fixed height (`rowHeight: 40`) is fastest — enables O(1) virtual bounds computation
+- Variable height (`rowHeight: (params) => number`) is flexible but requires measurement
+- Use fixed height for datasets > 10k rows unless variable height is required
+
+### Row Buffering
+- `rowBuffer`: number of rows rendered outside the visible viewport (default: 3)
+- Increase for smoother fast-scrolling; decrease to reduce DOM node count
+- Recommended range: 3–10
+
+### Stable References
+- Define `columns`, `cellRenderer`, `rowStyle`, `cellStyle` outside the render function or with `useMemo`/`useCallback`
+- Unstable column references cause full grid re-initialization on every render
+- `rowId` function must be stable
+
+### React Compiler Support
+- LyteNyte Grid is React Compiler compatible
+- With React Compiler enabled, manual `useMemo`/`useCallback` on renderers is less critical
+- Without React Compiler, always memoize renderer functions
+
+### Efficient Data Updates
+- Use `api.rowsUpdate(updatedRows)` for diff-patching — only changed rows re-render
+- Batch multiple updates before calling `rowsUpdate` — avoid calling it in a tight loop
+- For high-frequency updates (WebSocket, streaming), debounce with `setTimeout` or `requestAnimationFrame` before applying
+- `rowId` must be stable and unique — it's the key for diff detection
+
+### Data Source Choice for Scale
+- Client source (`useClientDataSource`): suitable up to ~500k rows in memory
+- Server source (`useServerDataSource`, PRO): for datasets beyond memory limits — only loads visible page
+- Infinite source (PRO): for unbounded scroll through server data
+
+### Column Virtualization
+- Enabled by default — only visible columns render
+- Avoid extremely wide columns that prevent virtualization from engaging
+
+## Rules
+- Never mutate the `rows` array directly — always provide a new array reference
+- `rowId` must return a stable, unique string or number per row
+- Avoid anonymous functions in JSX props for renderers — they break memoization
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/setup_cell_editing/SKILL.md
+++ b/.agents/skills/setup_cell_editing/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: setup_cell_editing
+description: Configures LyteNyte Grid cell editing — basic edits, custom editors, validation, bulk editing, full-row editing, linked cell edits, and programmatic editing.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid cell editing configuration.
+
+## Responsibility
+Set up all forms of cell editing: enabling editability, custom editor components, validation, and advanced edit modes.
+
+## What You Cover
+
+### Basic Cell Editing
+```ts
+// Enable editing on a column
+{ columnId: "name", editable: true }
+
+// Conditional editability
+{ columnId: "status", editable: (params) => params.row.isEditable }
+
+// Handle committed edits
+<Grid
+  onCellEditCommit={({ rowId, columnId, newValue, oldValue }) => {
+    setData((prev) =>
+      prev.map((row) => (row.id === rowId ? { ...row, [columnId]: newValue } : row)),
+    );
+  }}
+/>
+```
+
+### Custom Cell Editors
+Replace the default text input with any React component:
+```ts
+{
+  columnId: "priority",
+  editable: true,
+  cellEditor: (params) => (
+    <select
+      autoFocus
+      value={params.value}
+      onChange={(e) => params.commitEdit(e.target.value)}
+      onBlur={() => params.cancelEdit()}
+    >
+      <option value="low">Low</option>
+      <option value="medium">Medium</option>
+      <option value="high">High</option>
+    </select>
+  ),
+}
+```
+
+Editor params available:
+- `params.value` — current cell value
+- `params.commitEdit(newValue)` — save and close editor
+- `params.cancelEdit()` — discard and close editor
+- `params.row`, `params.column`, `params.api`
+
+### Edit Validation
+```ts
+{
+  columnId: "age",
+  editable: true,
+  editValidate: (params) => {
+    if (!params.newValue) return "Required";
+    if (Number(params.newValue) < 0) return "Must be positive";
+    if (Number(params.newValue) > 150) return "Unrealistic value";
+    return null; // null = valid, proceed with commit
+  },
+}
+```
+
+### Bulk Cell Editing
+Edit multiple selected cells at once — enabled automatically when cell range selection is active (PRO):
+```ts
+<Grid
+  onCellEditCommit={(params) => {
+    // params.affectedRows contains all rows in the selection
+    setData((prev) =>
+      prev.map((row) =>
+        params.affectedRowIds.includes(row.id)
+          ? { ...row, [params.columnId]: params.newValue }
+          : row,
+      ),
+    );
+  }}
+/>
+```
+
+### Full-Row Editing
+Edit all cells in a row simultaneously:
+```ts
+<Grid
+  editMode="row"
+  onRowEditCommit={({ rowId, newRow, oldRow }) => {
+    setData((prev) => prev.map((r) => (r.id === rowId ? newRow : r)));
+  }}
+/>
+```
+
+### Linked Cell Edits
+When editing one cell should update another:
+```ts
+{
+  columnId: "unitPrice",
+  editable: true,
+  onEditCommit: (params) => {
+    // Also update total when unit price changes
+    params.api.rowsUpdate([{
+      ...params.row,
+      unitPrice: params.newValue,
+      total: params.newValue * params.row.quantity,
+    }]);
+  },
+}
+```
+
+### Programmatic Editing
+Start/stop editing via the API:
+```ts
+api.editStart({ rowId: "row-1", columnId: "name" });
+api.editStop();
+api.editCommit();
+```
+
+### Edit Setter (controlled edit value)
+Override the value that gets committed:
+```ts
+{
+  columnId: "email",
+  editable: true,
+  editSetter: (params) => params.newValue.toLowerCase().trim(),
+}
+```
+
+## Rules
+- `onCellEditCommit` is where you persist changes — the grid does not mutate your data
+- `editValidate` returning a non-null string blocks the commit and shows the error
+- Custom `cellEditor` must call either `commitEdit` or `cancelEdit` — never leave the editor open
+- `editMode: "row"` and per-cell editing are mutually exclusive
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/setup_data_integration/SKILL.md
+++ b/.agents/skills/setup_data_integration/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: setup_data_integration
+description: Wires up the correct LyteNyte data source for the use case — client-side in-memory, server-side API, paginated, infinite scroll, or tree/hierarchical data.
+tools: ["read", "write"]
+---
+
+You are an expert in LyteNyte Grid data source integration.
+
+## Responsibility
+Select and configure the right data source hook for the data loading strategy.
+
+## Data Source Options
+
+### 1. Client-Side (`useClientDataSource`) — Core & PRO
+Best for: all data available in memory, up to ~500k rows.
+```ts
+import { useClientDataSource } from "@1771technologies/lytenyte-core";
+
+const source = useClientDataSource({ rows: data, rowId: (r) => r.id });
+```
+- Pass `source` to `<Grid rowSource={source} />`
+- Sorting, filtering, grouping all handled automatically client-side
+
+### 2. Server-Side (`useServerDataSource`) — PRO only
+Best for: large datasets loaded on demand, server handles sort/filter/group.
+```ts
+import { useServerDataSource } from "@1771technologies/lytenyte-pro";
+
+const source = useServerDataSource({
+  load: async ({ sortModel, filterModel, groupModel, skip, take }) => {
+    const res = await fetch("/api/data", { method: "POST", body: JSON.stringify({ sortModel, filterModel, skip, take }) });
+    const { rows, total } = await res.json();
+    return { rows, rowCount: total };
+  },
+  rowId: (r) => r.id,
+});
+```
+- `load` is called whenever sort/filter/group/scroll changes
+- Must return `{ rows, rowCount }` — `rowCount` is the total unfiltered count
+
+### 3. Tree Data (`useTreeDataSource`) — PRO only
+Best for: hierarchical/nested data (file trees, org charts, nested categories).
+```ts
+import { useTreeDataSource } from "@1771technologies/lytenyte-pro";
+
+const source = useTreeDataSource({
+  rows: flatData,
+  rowId: (r) => r.id,
+  pathField: "path", // dot-separated path string e.g. "parent.child"
+  // or parentField: "parentId"
+});
+```
+
+### 4. Paginated Source — PRO only
+Best for: traditional page-by-page navigation.
+- Uses `useServerDataSource` with `skip`/`take` parameters
+- Manage current page in component state, pass to `load` callback
+
+### 5. Infinite Scroll Source — PRO only
+Best for: endless scroll through server data.
+- Uses `useServerDataSource` — the grid automatically requests more rows as user scrolls
+
+## Updating Data (Client-Side)
+```ts
+// Add rows
+api.rowsAdd([newRow]);
+
+// Update rows (diff-patch by rowId)
+api.rowsUpdate([updatedRow]);
+
+// Delete rows
+api.rowsDelete([rowId]);
+```
+
+## Rules
+- Always define `rowId` — required for all data sources
+- For server sources, `load` must be a stable function reference (wrap in `useCallback`)
+- Never mix client and server source patterns in the same grid instance
+- PRO data sources require `@1771technologies/lytenyte-pro` import and a valid license
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/.agents/skills/validate_and_refine_config/SKILL.md
+++ b/.agents/skills/validate_and_refine_config/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: validate_and_refine_config
+description: Validates a generated LyteNyte Grid configuration against TypeScript types, enforces best practices, and fixes common mistakes before code generation.
+tools: ["read", "write"]
+---
+
+You are a LyteNyte Grid configuration validator and quality enforcer.
+
+## Responsibility
+Review a grid configuration for correctness, type safety, and best practices before it becomes final code.
+
+## What You Check
+
+### Required Fields
+- [ ] `rowId` is defined on the data source
+- [ ] Every column has a unique `columnId`
+- [ ] `<Grid rowSource={source} />` — `rowSource` prop is present
+- [ ] CSS import is present (`grid.css` + a theme)
+- [ ] PRO features use `@1771technologies/lytenyte-pro` imports (not core)
+- [ ] `activateLicense()` is called before `<Grid>` renders when using PRO
+
+### Type Safety
+- [ ] `GridSpec` generic is defined if custom API extensions or column extensions are used
+- [ ] `cellRenderer` params typed as `CellRendererParams<Spec>` not `any`
+- [ ] `rowStyle`/`cellStyle` params typed as `RowParams<Spec>` / `CellParams<Spec>`
+- [ ] `aggregations` values match `Aggregator` type (string built-in or `{ fn: AggregationFn }`)
+- [ ] `sortDimensions` entries have valid `columnId` references
+
+### Common Mistakes to Fix
+- Anonymous functions in JSX props for renderers → extract to stable references
+- Missing `key` prop on list items inside cell renderers
+- `groupDimensions` set without `rowGroupColumn` defined → add a default group column
+- `aggregations` defined without `groupDimensions` → aggregations only work with grouping
+- `filterType` on a column that doesn't match the data type
+- `pin: true` instead of `pin: "start"` (wrong type)
+- Importing from `@1771technologies/lytenyte-core` when using PRO-only features
+
+### Best Practices
+- [ ] Renderer functions are defined outside the component or memoized
+- [ ] `columns` array is defined outside the component or in `useMemo`
+- [ ] `rowHeight` is a fixed number for large datasets (> 10k rows)
+- [ ] `rowId` returns a primitive (string or number), not an object
+- [ ] No direct mutation of the `rows` array
+
+### PRO Feature Checklist
+If any of these are used, confirm `@1771technologies/lytenyte-pro` is the import source:
+- `useServerDataSource`
+- `useTreeDataSource`
+- Cell range selection
+- Pivot configuration
+- Expression filters
+- Prebuilt components (PillManager, ColumnManager, TreeView, SmartSelect)
+- Clipboard operations
+- Label/having filters
+
+## Output
+Return either:
+- A corrected configuration with a list of changes made
+- A validation report listing issues found (if not auto-fixable)
+
+## Rules
+- Do not change intentional design decisions — only fix errors and type mismatches
+- Flag PRO dependencies clearly so the user knows what requires a license
+- Follow Prettier config: 110 char width, double quotes, trailing commas, 2-space indent

--- a/README.md
+++ b/README.md
@@ -385,6 +385,44 @@ npm install --save @1771technologies/lytenyte-pro
 npm install --save @1771technologies/lytenyte-core
 ```
 
+## AI Agent Skills
+
+LyteNyte Grid ships with a set of [agent skills](https://agentskills.io/) — reusable instruction sets that give AI coding agents (Cursor, Kiro, Claude Code, Codex, and [more](https://www.npmjs.com/package/skills)) deep knowledge of the grid's APIs, patterns, and best practices.
+
+Install the skills into your project with the `skills` CLI:
+
+```sh
+npx skills add https://github.com/1771-technologies/lytenyte/tree/main/.agents/skills
+```
+
+Or install specific skills only:
+
+```sh
+npx skills add https://github.com/1771-technologies/lytenyte/tree/main/.agents/skills --skill generate_grid_from_intent --skill generate_grid_code
+```
+
+Once installed, your agent can generate complete, production-ready grid implementations from a natural language prompt, a dataset, or a partial config — using the correct Core or PRO APIs, proper TypeScript generics, and all required CSS imports.
+
+**Available skills:**
+
+| Skill | What it does |
+|---|---|
+| `generate_grid_from_intent` | Parses natural language or a dataset into a structured grid plan |
+| `design_grid_structure` | Scaffolds columns, `GridSpec` types, `rowId`, and `useClientDataSource` |
+| `configure_grid_features` | Wires sorting, filtering, grouping, aggregation, and row selection |
+| `apply_ui_customization` | Cell/header renderers, conditional styling, column layout |
+| `setup_data_integration` | Picks and wires the right data source hook |
+| `configure_server_data_source` | PRO server-side load callbacks, pagination, optimistic updates |
+| `setup_cell_editing` | Editable cells, custom editors, validation, bulk/row/linked edits |
+| `apply_business_logic` | Custom aggregations, KPIs, expression filters, having filters, pivots |
+| `enhance_grid_with_extensions` | Export (CSV/Excel/Parquet/Arrow), clipboard, row actions, API extensions |
+| `configure_theming` | CSS imports, theme selection, CSS custom properties, Tailwind/CSS Modules |
+| `optimize_grid_performance` | Row height strategy, buffering, stable refs, React Compiler, update batching |
+| `enable_realtime_updates` | WebSocket/SSE integration, diff-patching, cell flash, high-frequency updates |
+| `validate_and_refine_config` | Type-checks config, fixes common mistakes, enforces best practices |
+| `apply_security_controls` | Column visibility by role, data masking, conditional editability |
+| `generate_grid_code` | Produces the final React component with all imports and JSX |
+
 ## Quick Start
 
 - Begin with our comprehensive [getting started guide](https://www.1771technologies.com/docs/intro-getting-started).

--- a/documentation-v2/docs/(ai-agents)/ai-agent-skills.mdx
+++ b/documentation-v2/docs/(ai-agents)/ai-agent-skills.mdx
@@ -1,0 +1,401 @@
+---
+title: Agent Skills
+step: Explore all 15 LyteNyte Grid agent skills — what each one covers, its inputs and outputs, and how they chain together.
+description: >
+  A reference for all 15 LyteNyte Grid agent skills — what each skill covers, its inputs and
+  outputs, how skills interact, and how to extend the system with new skills.
+---
+
+Agent skills are focused instruction sets that give AI coding agents deep, accurate knowledge of
+one specific area of LyteNyte Grid. Instead of a single large prompt that covers everything, each
+skill is scoped to a domain — column design, feature wiring, theming, export, and so on.
+
+When you prompt your agent to build a grid, it selects and chains the relevant skills automatically.
+For targeted changes, it invokes a single skill directly.
+
+## Why Skills Instead of Direct Generation
+
+A single monolithic prompt for a complex library like LyteNyte Grid has two problems: it's too
+large to fit in context reliably, and it mixes concerns in ways that cause the agent to make
+mistakes at the boundaries.
+
+Skills solve this by:
+
+- **Scoping knowledge** — each skill only knows what it needs to know for its domain
+- **Encoding constraints** — rules, required fields, and common mistakes are baked in per skill
+- **Enabling composition** — skills produce structured outputs that downstream skills consume
+- **Staying current** — skills are versioned alongside the grid source
+
+## Skill Categories
+
+Skills are grouped into four categories based on when they run in the generation pipeline:
+
+| Category | Skills |
+|---|---|
+| Orchestration | `generate_grid_from_intent` |
+| Structure & Data | `design_grid_structure`, `setup_data_integration`, `configure_server_data_source` |
+| Features & Logic | `configure_grid_features`, `setup_cell_editing`, `apply_business_logic`, `enhance_grid_with_extensions`, `enable_realtime_updates`, `apply_security_controls` |
+| Presentation | `apply_ui_customization`, `configure_theming`, `optimize_grid_performance` |
+| Output & Quality | `validate_and_refine_config`, `generate_grid_code` |
+
+## Available Skills
+
+### `generate_grid_from_intent`
+
+The orchestration entry point. Parses a natural language description or dataset sample and
+coordinates all other skills to produce a complete grid.
+
+**Input:** Natural language prompt, dataset sample (JSON or TypeScript type), or partial config  
+**Output:** A structured config object passed to downstream skills — columns, features list, data source type, customizations
+
+**What it does:**
+- Extracts entities, data types, and desired features from the prompt
+- Infers column names and types from dataset samples
+- Maps intent keywords to grid features (e.g. "group by" → `groupDimensions`, "export" → export API)
+- Decides which skills to invoke and in what order
+- Defaults to client-side data source when intent is ambiguous
+
+---
+
+### `design_grid_structure`
+
+Scaffolds the foundational grid setup — typed column definitions, `GridSpec` generics, field
+configuration, and data source initialization.
+
+**Input:** Column list with inferred types, dataset shape  
+**Output:** `GridSpec` interface, `columns` array, `useClientDataSource` call, minimal `<Grid>` JSX
+
+**What it does:**
+- Constructs the `GridSpec` generic interface (`<T, C, S, E>`) for type-safe columns and API
+- Builds the `columns` array with correct TypeScript types
+- Configures `field` as a string path, dot-path, index, or function
+- Infers column `type`: `"text"`, `"number"`, `"date"`, `"boolean"`
+- Initializes `useClientDataSource` with `rows` and `rowId`
+- Adds `columnGroups`, `columnMarker`, and `columnBase` when appropriate
+
+---
+
+### `configure_grid_features`
+
+Wires functional features onto an existing grid config using declarative props.
+
+**Input:** Feature list from `generate_grid_from_intent`, existing grid config  
+**Output:** Updated `<Grid>` JSX with feature props, controlled state handlers
+
+**What it covers:**
+- Sorting — `sortDimensions`, `onSortDimensionsChange`, multi-column sort
+- Filtering — `filterModel`, `quickSearch`, per-column `filterType`
+- Grouping — `groupDimensions`, `rowGroupColumn`
+- Aggregation — `aggregations` with built-ins (`"sum"`, `"avg"`, `"min"`, `"max"`, `"count"`) or custom functions
+- Row selection — `rowSelection` with `"single"`, `"multi"`, isolated, or linked modes
+- Column visibility — `columnVisibility`, `onColumnVisibilityChange`
+
+---
+
+### `apply_ui_customization`
+
+Handles all visual and rendering customization — cell renderers, header renderers, conditional
+styling, value formatting, column sizing, and pinning.
+
+**Input:** Column list, feature config, styling requirements  
+**Output:** Updated columns with `cellRenderer`, `headerRenderer`, `cellStyle`, `rowStyle`, layout props
+
+**What it covers:**
+- Cell renderers — `(params: CellRendererParams<Spec>) => ReactNode`
+- Header renderers — custom sort indicators, filter icons, tooltips
+- Conditional styling — `cellStyle` and `rowStyle` returning CSS class strings or inline style objects
+- Column layout — `width`, `minWidth`, `maxWidth`, `pin: "start" | "end"`, `flex`, `hidden`
+- Row height — fixed number or `(params) => number` for variable height
+
+---
+
+### `setup_data_integration`
+
+Selects and configures the correct data source hook for the loading strategy.
+
+**Input:** Data source type from `generate_grid_from_intent`, dataset or API description  
+**Output:** Correct data source hook call with all required parameters
+
+**Data sources it can wire:**
+
+| Hook | Edition | Best for |
+|---|---|---|
+| `useClientDataSource` | Core & PRO | All data in memory, up to ~500k rows |
+| `useServerDataSource` | PRO | Large datasets, server handles sort/filter/group |
+| `useTreeDataSource` | PRO | Hierarchical/nested data |
+| Paginated (via server source) | PRO | Traditional page navigation |
+| Infinite scroll (via server source) | PRO | Unbounded scroll through server data |
+
+---
+
+### `configure_server_data_source`
+
+Implements the full `useServerDataSource` contract — load callback, server-side sort/filter/group,
+pagination, tree loading, optimistic updates, and refresh.
+
+**Input:** API description, server capabilities, data shape  
+**Output:** Complete `useServerDataSource` call with typed `load` callback
+
+**What it covers:**
+- `load` callback with `sortModel`, `filterModel`, `groupModel`, `groupKeys`, `skip`, `take`, `signal`
+- `AbortSignal` handling to cancel stale requests
+- Server-side sorting, filtering, and grouping patterns
+- Lazy group loading via `groupKeys`
+- Server-side tree data with parent/child loading
+- Optimistic update pattern (apply → sync → revert on failure)
+- `source.refresh()` for manual reload triggers
+
+---
+
+### `setup_cell_editing`
+
+Configures all forms of cell editing — basic edits, custom editors, validation, bulk editing,
+full-row editing, and linked cell edits.
+
+**Input:** Editable column list, validation rules, edit mode  
+**Output:** Updated columns with `editable`, `cellEditor`, `editValidate`, `editSetter`; grid with `onCellEditCommit`
+
+**What it covers:**
+- Per-column `editable: true` or conditional `editable: (params) => boolean`
+- Custom `cellEditor` components with `commitEdit` / `cancelEdit` callbacks
+- `editValidate` — return an error string to block commit, `null` to allow
+- `editSetter` — transform the value before it's committed
+- Bulk editing across cell range selections (PRO)
+- `editMode: "row"` for full-row editing with `onRowEditCommit`
+- Linked edits — updating related cells when one cell changes
+- Programmatic editing via `api.editStart()`, `api.editStop()`, `api.editCommit()`
+
+---
+
+### `apply_business_logic`
+
+Layers domain-specific logic onto the grid — custom aggregations, KPI calculations, expression
+filters, having filters, pivot measures, and custom sort/group functions.
+
+**Input:** Business requirements, domain data types  
+**Output:** Custom aggregation functions, expression filter config, pivot measures, group/sort functions
+
+**What it covers:**
+- Custom `AggregationFn<T>` — weighted averages, margin %, YoY delta, any KPI
+- Expression filters (PRO) — per-row filter expressions with arithmetic, comparisons, string/date functions
+- Having filters (PRO) — filter applied after grouping, like SQL `HAVING`
+- Label filters (PRO) — filter applied to group label rows
+- Pivot measures (PRO) — custom measure functions with `grandTotals` config
+- `groupFn` — custom group key derivation (e.g. fiscal quarter from date)
+- `sortFn` — custom sort comparator (e.g. status priority order)
+- Pinned summary rows via `rowsPinned`
+
+---
+
+### `enhance_grid_with_extensions`
+
+Adds advanced capabilities — data export, clipboard, row actions, and custom API extensions.
+
+**Input:** Extension requirements (export formats, row actions, custom API methods)  
+**Output:** Export button wiring, API extension type and implementation, row action column
+
+**What it covers:**
+- Export — `api.exportCsv()`, `api.exportExcel()`, `api.exportParquet()`, `api.exportArrow()`
+- Clipboard — `api.clipboardCopy()`, `api.clipboardPaste()` (PRO, requires cell range selection)
+- Row action columns — cell renderer with edit/delete/custom action buttons
+- Custom API extensions — typed imperative methods added via `apiExtension` prop
+
+---
+
+### `configure_theming`
+
+Sets up the visual theme — CSS imports, custom property overrides, Tailwind, CSS Modules, and
+Emotion/CSS-in-JS integration.
+
+**Input:** Theme preference, styling framework in use  
+**Output:** Correct CSS import statements, custom property overrides, wrapper styles
+
+**What it covers:**
+- Required `grid.css` import (always)
+- Prebuilt themes: `light`, `dark`, `light-dark`, `cotton-candy`, `shadcn`, `teal`, `term`
+- CSS custom property overrides for colors, row height, header height, font size
+- Tailwind integration — classes on wrappers and cell renderer content
+- CSS Modules — module class on the grid wrapper
+- Emotion/CSS-in-JS — `css` prop on the wrapper element
+- Dark mode toggle patterns
+
+---
+
+### `optimize_grid_performance`
+
+Configures the grid for production-scale performance — row height strategy, buffering, stable
+references, React Compiler compatibility, and efficient update patterns.
+
+**Input:** Dataset size, update frequency, performance requirements  
+**Output:** Performance-optimized grid config with correct row height, buffer settings, and memoization
+
+**What it covers:**
+- Fixed `rowHeight` for O(1) virtual bounds (recommended for > 10k rows)
+- `rowBuffer` tuning — rows rendered outside the viewport (default: 3, range: 3–10)
+- Stable `columns`, renderer, and `rowId` references
+- React Compiler compatibility notes
+- `api.rowsUpdate()` for diff-patching instead of full array replacement
+- Batching high-frequency updates before applying
+- Column virtualization behavior
+
+---
+
+### `enable_realtime_updates`
+
+Integrates live data streams — WebSocket, SSE, auto-refresh, diff-patching, and cell flash.
+
+**Input:** Data stream type (WebSocket/SSE/polling), update frequency, row data type  
+**Output:** Effect hook with stream connection, buffered update loop, cell flash config
+
+**What it covers:**
+- `api.rowsUpdate()`, `api.rowsAdd()`, `api.rowsDelete()` — the three mutation methods
+- WebSocket integration with `requestAnimationFrame` batching
+- SSE (Server-Sent Events) integration
+- Debounced auto-refresh polling pattern
+- `flashOnChange` and `flashDuration` per column for visual diff highlighting
+- High-frequency update strategy — `Map<rowId, Row>` buffer, deduplicate by rowId, flush per frame
+
+---
+
+### `apply_security_controls`
+
+Implements application-level security patterns — column visibility by role, data masking,
+conditional editability, and row-level access control.
+
+**Input:** User role/permissions model, sensitive column list  
+**Output:** Role-filtered columns, masking cell renderers, conditional `editable` functions, audit log wiring
+
+**What it covers:**
+- Role-based column visibility via `hidden` or `columnVisibility` prop
+- Data masking via cell renderer (show `••••••••` for unauthorized users)
+- Conditional `editable` — prevent editing based on role or row state
+- Row-level filtering enforced server-side (never client-only for sensitive data)
+- `isRowSelectable` — disable row selection by role
+- Audit trail on `onCellEditCommit`
+
+:::caution
+
+`hidden: true` and client-side masking are UI-only. For truly sensitive data, always enforce
+access control at the API/server level. The row data is still present in the JavaScript runtime
+even when a column is hidden.
+
+:::
+
+---
+
+### `validate_and_refine_config`
+
+Reviews a generated config for correctness, type safety, and best practices before code generation.
+
+**Input:** Complete grid config from upstream skills  
+**Output:** Corrected config with a list of changes, or a validation report for non-auto-fixable issues
+
+**What it checks:**
+- `rowId` is defined on the data source
+- Every column has a unique `columnId`
+- `rowSource` prop is present on `<Grid>`
+- CSS imports are present (`grid.css` + a theme)
+- PRO features use `@1771technologies/lytenyte-pro` imports
+- `activateLicense()` is called before `<Grid>` renders when using PRO
+- `GridSpec` generic is defined when custom extensions are used
+- Renderer params are typed correctly (not `any`)
+- Anonymous renderer functions in JSX props are extracted to stable references
+- `groupDimensions` is set when `aggregations` is defined
+- `pin: "start"` not `pin: true`
+
+---
+
+### `generate_grid_code`
+
+Produces the final, ready-to-run React component with all imports, TypeScript types, hooks, and JSX.
+
+**Input:** Validated config from `validate_and_refine_config`  
+**Output:** Complete `.tsx` file — imports, `GridSpec`, `columns`, data source hook, `<Grid>` JSX
+
+**What it produces:**
+- Full React functional component with TypeScript
+- Correct import statements (package + CSS)
+- `GridSpec` type definition
+- Data source hook call
+- `<Grid>` JSX with all configured props
+- Headless component composition when custom layout is needed
+
+## Skill Execution Flow
+
+For a new grid from scratch, the agent follows this sequence:
+
+```
+generate_grid_from_intent
+  → design_grid_structure
+  → configure_grid_features
+  → apply_ui_customization
+  → setup_data_integration
+  → [optional: setup_cell_editing]
+  → [optional: apply_business_logic]
+  → [optional: enhance_grid_with_extensions]
+  → [optional: configure_theming]
+  → [optional: optimize_grid_performance]
+  → [optional: enable_realtime_updates]
+  → [optional: apply_security_controls]
+  → validate_and_refine_config
+  → generate_grid_code
+```
+
+For targeted requests, the agent invokes only the relevant skill:
+
+- "Add Excel export" → `enhance_grid_with_extensions`
+- "Switch to server-side loading" → `configure_server_data_source`
+- "Add inline editing with validation" → `setup_cell_editing`
+- "Apply the shadcn theme" → `configure_theming`
+
+## How Skills Interact
+
+Skills communicate through a shared config object. Each skill reads from and writes to this
+object as it runs:
+
+```
+generate_grid_from_intent → { dataset, columns, features, dataSourceType, customizations }
+design_grid_structure     → adds GridSpec, typed columns, rowId
+configure_grid_features   → adds sortDimensions, filterModel, groupDimensions, rowSelection
+apply_ui_customization    → adds cellRenderer, headerRenderer, cellStyle, layout props
+setup_data_integration    → adds data source hook call
+validate_and_refine_config→ corrects errors, enforces rules
+generate_grid_code        → consumes full config, emits final component
+```
+
+## Extensibility
+
+You can add new skills to `.agents/skills/` in your project. A skill is a Markdown file with a
+YAML frontmatter block and a body that describes the skill's responsibility, inputs, outputs, and
+rules. The agent picks up any skill in `.agents/skills/` automatically.
+
+A minimal custom skill looks like this:
+
+```md
+---
+name: my_custom_skill
+description: Does something specific to my project.
+tools: ["read", "write"]
+---
+
+## Responsibility
+Describe what this skill does.
+
+## Rules
+- Rule 1
+- Rule 2
+```
+
+## Constraints and Limitations
+
+- Skills encode knowledge of the grid API at the time they were written — update them when you
+  upgrade LyteNyte Grid to a new major version
+- Skills do not have access to your runtime data — they work from types and samples you provide
+- PRO skills (`configure_server_data_source`, tree data, pivoting, expressions) require a valid
+  PRO license to use the generated code in production
+- The agent may invoke skills in a different order than the default pipeline for targeted requests
+  — this is expected behavior
+
+## Next Steps
+
+::next[/docs/ai-examples]

--- a/documentation-v2/docs/(ai-agents)/ai-examples.mdx
+++ b/documentation-v2/docs/(ai-agents)/ai-examples.mdx
@@ -1,0 +1,531 @@
+---
+title: Examples
+step: See real prompts and their generated grid outputs — from simple client-side grids to server-side loading, real-time updates, and security patterns.
+description: >
+  Real-world prompts and their generated outputs — from simple client-side grids to server-side
+  loading, real-time updates, editing, pivoting, and security patterns.
+---
+
+This page shows a range of prompts and the grid configurations they produce. Each example maps
+the input prompt to the skills invoked and the key parts of the output.
+
+## Simple Client-Side Grid
+
+**Prompt:**
+> "Create a grid for this data: employees with id, name, department, and salary."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `generate_grid_code`
+
+**Output:**
+
+```tsx
+import { Grid, useClientDataSource } from "@1771technologies/lytenyte-core";
+import type { Grid as GridTypes } from "@1771technologies/lytenyte-core";
+import "@1771technologies/lytenyte-core/grid.css";
+import "@1771technologies/lytenyte-core/light-dark.css";
+
+interface Employee {
+  id: string;
+  name: string;
+  department: string;
+  salary: number;
+}
+
+type Spec = GridTypes.GridSpec<Employee>;
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "name", headerName: "Name", field: "name", width: 200 },
+  { columnId: "department", headerName: "Department", field: "department", width: 160 },
+  { columnId: "salary", headerName: "Salary", field: "salary", type: "number", width: 120 },
+];
+
+export function EmployeeGrid({ data }: { data: Employee[] }) {
+  const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.id });
+
+  return (
+    <div style={{ height: 500 }}>
+      <Grid rowSource={source} columns={columns} />
+    </div>
+  );
+}
+```
+
+**What changed from the prompt:**
+- `id` is used as `rowId` — inferred from the field name
+- `salary` gets `type: "number"` — inferred from the field name
+- `light-dark.css` is chosen as the default theme (auto system preference)
+
+---
+
+## Sorting and Filtering
+
+**Prompt:**
+> "Employee grid with sorting on all columns and text filtering on name and department."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `configure_grid_features` → `generate_grid_code`
+
+**Key additions to the output:**
+
+```tsx
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "name", headerName: "Name", field: "name", width: 200, filterType: "text" },
+  { columnId: "department", headerName: "Department", field: "department", width: 160, filterType: "text" },
+  { columnId: "salary", headerName: "Salary", field: "salary", type: "number", width: 120 },
+];
+
+export function EmployeeGrid({ data }: { data: Employee[] }) {
+  const [sortDimensions, setSortDimensions] = useState<GridTypes.DimensionSort<Spec>[]>([]);
+  const [filterModel, setFilterModel] = useState<GridTypes.FilterModel<Spec>>({});
+
+  const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.id });
+
+  return (
+    <div style={{ height: 500 }}>
+      <Grid
+        rowSource={source}
+        columns={columns}
+        sortDimensions={sortDimensions}
+        onSortDimensionsChange={setSortDimensions}
+        filterModel={filterModel}
+        onFilterModelChange={setFilterModel}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## Grouping and Aggregation
+
+**Prompt:**
+> "Sales grid grouped by region, with sum of revenue and average of units sold per group."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `configure_grid_features` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+interface SalesRow {
+  id: string;
+  region: string;
+  product: string;
+  revenue: number;
+  unitsSold: number;
+}
+
+type Spec = GridTypes.GridSpec<SalesRow>;
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "region", headerName: "Region", field: "region", width: 140 },
+  { columnId: "product", headerName: "Product", field: "product", width: 180 },
+  { columnId: "revenue", headerName: "Revenue", field: "revenue", type: "number", width: 130 },
+  { columnId: "unitsSold", headerName: "Units Sold", field: "unitsSold", type: "number", width: 120 },
+];
+
+export function SalesGrid({ data }: { data: SalesRow[] }) {
+  const source = useClientDataSource<Spec>({
+    rows: data,
+    rowId: (r) => r.id,
+    groupDimensions: [{ columnId: "region" }],
+    aggregations: {
+      revenue: "sum",
+      unitsSold: "avg",
+    },
+  });
+
+  return (
+    <div style={{ height: 500 }}>
+      <Grid rowSource={source} columns={columns} />
+    </div>
+  );
+}
+```
+
+---
+
+## Custom Cell Renderers
+
+**Prompt:**
+> "Order grid with a status badge column (active/pending/cancelled) and a currency-formatted total."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `apply_ui_customization` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+import type { CellRendererParams } from "@1771technologies/lytenyte-core/types";
+
+const statusColors = {
+  active: "bg-green-100 text-green-800",
+  pending: "bg-yellow-100 text-yellow-800",
+  cancelled: "bg-red-100 text-red-800",
+};
+
+function StatusCell({ value }: CellRendererParams<Spec>) {
+  const color = statusColors[value as keyof typeof statusColors] ?? "bg-gray-100 text-gray-800";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
+      {value}
+    </span>
+  );
+}
+
+function TotalCell({ value }: CellRendererParams<Spec>) {
+  return (
+    <span>
+      {new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(Number(value))}
+    </span>
+  );
+}
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "orderId", headerName: "Order ID", field: "orderId", width: 120 },
+  { columnId: "status", headerName: "Status", field: "status", width: 120, cellRenderer: StatusCell },
+  { columnId: "total", headerName: "Total", field: "total", type: "number", width: 130, cellRenderer: TotalCell },
+];
+```
+
+---
+
+## Inline Cell Editing with Validation
+
+**Prompt:**
+> "Inventory grid where quantity and price are editable. Quantity must be a positive integer. Price must be > 0."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `setup_cell_editing` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "sku", headerName: "SKU", field: "sku", width: 120 },
+  { columnId: "name", headerName: "Name", field: "name", width: 200 },
+  {
+    columnId: "quantity",
+    headerName: "Quantity",
+    field: "quantity",
+    type: "number",
+    width: 110,
+    editable: true,
+    editValidate: (params) => {
+      const val = Number(params.newValue);
+      if (!Number.isInteger(val)) return "Must be a whole number";
+      if (val < 0) return "Must be positive";
+      return null;
+    },
+  },
+  {
+    columnId: "price",
+    headerName: "Price",
+    field: "price",
+    type: "number",
+    width: 110,
+    editable: true,
+    editValidate: (params) => {
+      if (Number(params.newValue) <= 0) return "Must be greater than 0";
+      return null;
+    },
+  },
+];
+
+export function InventoryGrid({ data, onUpdate }: { data: InventoryRow[]; onUpdate: (row: InventoryRow) => void }) {
+  const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.sku });
+
+  return (
+    <div style={{ height: 500 }}>
+      <Grid
+        rowSource={source}
+        columns={columns}
+        onCellEditCommit={({ rowId, columnId, newValue }) => {
+          const row = data.find((r) => r.sku === rowId);
+          if (row) onUpdate({ ...row, [columnId]: newValue });
+        }}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## Server-Side Loading
+
+**Prompt:**
+> "User grid that loads from /api/users with server-side sorting and filtering. Large dataset."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `configure_server_data_source` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+import { Grid, useServerDataSource, activateLicense } from "@1771technologies/lytenyte-pro";
+import type { Grid as GridTypes } from "@1771technologies/lytenyte-pro";
+import "@1771technologies/lytenyte-pro/grid.css";
+import "@1771technologies/lytenyte-pro/light-dark.css";
+
+activateLicense("YOUR_LICENSE_KEY");
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  createdAt: string;
+}
+
+type Spec = GridTypes.GridSpec<User>;
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "name", headerName: "Name", field: "name", width: 200, filterType: "text" },
+  { columnId: "email", headerName: "Email", field: "email", width: 240, filterType: "text" },
+  { columnId: "role", headerName: "Role", field: "role", width: 120, filterType: "set" },
+  { columnId: "createdAt", headerName: "Created", field: "createdAt", type: "date", width: 140 },
+];
+
+export function UserGrid() {
+  const source = useServerDataSource<Spec>({
+    rowId: (r) => r.id,
+    load: useCallback(async ({ sortModel, filterModel, skip, take, signal }) => {
+      const res = await fetch("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sortModel, filterModel, skip, take }),
+        signal,
+      });
+      const { rows, total } = await res.json();
+      return { rows, rowCount: total };
+    }, []),
+  });
+
+  return (
+    <div style={{ height: 600 }}>
+      <Grid rowSource={source} columns={columns} rowHeight={40} />
+    </div>
+  );
+}
+```
+
+---
+
+## Real-Time Updates via WebSocket
+
+**Prompt:**
+> "Stock ticker grid that receives live price updates over WebSocket. Flash cells when price changes."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `enable_realtime_updates` → `optimize_grid_performance` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+interface StockRow {
+  symbol: string;
+  price: number;
+  change: number;
+  volume: number;
+}
+
+type Spec = GridTypes.GridSpec<StockRow>;
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "symbol", headerName: "Symbol", field: "symbol", width: 100 },
+  {
+    columnId: "price",
+    headerName: "Price",
+    field: "price",
+    type: "number",
+    width: 120,
+    flashOnChange: true,
+    flashDuration: 400,
+  },
+  { columnId: "change", headerName: "Change", field: "change", type: "number", width: 110 },
+  { columnId: "volume", headerName: "Volume", field: "volume", type: "number", width: 120 },
+];
+
+export function StockGrid({ initialData }: { initialData: StockRow[] }) {
+  const source = useClientDataSource<Spec>({ rows: initialData, rowId: (r) => r.symbol });
+  const apiRef = useRef<GridTypes.API<Spec> | null>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket("wss://api.example.com/stocks");
+    const buffer = new Map<string, StockRow>();
+
+    ws.onmessage = (event) => {
+      const row: StockRow = JSON.parse(event.data);
+      buffer.set(row.symbol, row); // deduplicate — latest wins
+    };
+
+    const flush = () => {
+      if (buffer.size > 0 && apiRef.current) {
+        apiRef.current.rowsUpdate([...buffer.values()]);
+        buffer.clear();
+      }
+      requestAnimationFrame(flush);
+    };
+    requestAnimationFrame(flush);
+
+    return () => ws.close();
+  }, []);
+
+  return (
+    <div style={{ height: 500 }}>
+      <Grid
+        rowSource={source}
+        columns={columns}
+        rowHeight={36}
+        apiExtension={(api) => {
+          apiRef.current = api;
+          return {};
+        }}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## Export with Custom Button
+
+**Prompt:**
+> "Report grid with a toolbar button that exports to Excel with a timestamped filename."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `enhance_grid_with_extensions` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+type Spec = GridTypes.GridSpec<ReportRow, object, RowSource, { exportTimestamped: () => void }>;
+
+export function ReportGrid({ data }: { data: ReportRow[] }) {
+  const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.id });
+  const apiRef = useRef<GridTypes.API<Spec> | null>(null);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: 600 }}>
+      <div style={{ padding: "8px 0" }}>
+        <button onClick={() => apiRef.current?.exportTimestamped()}>Export to Excel</button>
+      </div>
+      <div style={{ flex: 1 }}>
+        <Grid
+          rowSource={source}
+          columns={columns}
+          apiExtension={(api) => {
+            apiRef.current = api;
+            return {
+              exportTimestamped: () =>
+                api.exportExcel({ fileName: `report-${new Date().toISOString().slice(0, 10)}.xlsx` }),
+            };
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## Role-Based Column Visibility
+
+**Prompt:**
+> "HR grid where salary and SSN columns are only visible to admin users."
+
+**Skills invoked:** `generate_grid_from_intent` → `design_grid_structure` → `apply_security_controls` → `generate_grid_code`
+
+**Key output:**
+
+```tsx
+export function HRGrid({ data, userRole }: { data: Employee[]; userRole: "admin" | "manager" | "viewer" }) {
+  const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.id });
+
+  const columnVisibility = useMemo(
+    () => ({
+      salary: userRole === "admin",
+      ssn: userRole === "admin",
+    }),
+    [userRole],
+  );
+
+  return (
+    <div style={{ height: 500 }}>
+      <Grid rowSource={source} columns={columns} columnVisibility={columnVisibility} />
+    </div>
+  );
+}
+```
+
+:::caution
+
+`columnVisibility` is UI-only. The row data is still present in the JavaScript runtime. For
+truly sensitive fields, exclude them server-side before sending to the client.
+
+:::
+
+---
+
+## Feature Combinations
+
+The table below shows how the output changes as you add features to the same base prompt:
+
+| Prompt addition | Skills added | Key output change |
+|---|---|---|
+| "with sorting" | `configure_grid_features` | `sortDimensions` state + `onSortDimensionsChange` |
+| "with text search" | `configure_grid_features` | `quickSearch` state + `onQuickSearchChange` |
+| "grouped by category" | `configure_grid_features` | `groupDimensions` on data source |
+| "with sum totals" | `configure_grid_features` | `aggregations` on data source |
+| "editable cells" | `setup_cell_editing` | `editable: true` + `onCellEditCommit` |
+| "export to CSV" | `enhance_grid_with_extensions` | `api.exportCsv()` wired to a button |
+| "server-side" | `configure_server_data_source` | `useServerDataSource` with `load` callback |
+| "real-time via WebSocket" | `enable_realtime_updates` | `useEffect` with WS + `api.rowsUpdate()` |
+| "shadcn theme" | `configure_theming` | `import ".../shadcn.css"` |
+| "admin-only columns" | `apply_security_controls` | `columnVisibility` derived from role |
+
+---
+
+## Edge Cases
+
+### No `id` field in dataset
+
+When the dataset has no obvious ID field, the agent picks the most unique-looking column and
+notes the assumption:
+
+```tsx
+// No 'id' field found — using 'email' as rowId (assumed unique)
+const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.email });
+```
+
+### Ambiguous data source intent
+
+When the prompt says "large dataset" without specifying server-side, the agent defaults to
+client-side and adds a comment:
+
+```tsx
+// Using client-side source. For datasets > 500k rows, switch to useServerDataSource (PRO).
+const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.id });
+```
+
+### PRO feature without license call
+
+If the prompt implies a PRO feature (server-side, pivoting, tree data), the agent always
+includes `activateLicense()` and a comment:
+
+```tsx
+// PRO license required — replace with your license key
+activateLicense("YOUR_LICENSE_KEY");
+```
+
+### Missing CSS import
+
+The `validate_and_refine_config` skill catches missing CSS imports before code generation.
+If somehow omitted, the grid renders blank — the fix is always:
+
+```tsx
+import "@1771technologies/lytenyte-core/grid.css";
+import "@1771technologies/lytenyte-core/light-dark.css";
+```
+
+## Next Steps
+
+::next[/docs/intro-getting-started]
+::next[/docs/ai-agent-skills]

--- a/documentation-v2/docs/(ai-agents)/ai-getting-started.mdx
+++ b/documentation-v2/docs/(ai-agents)/ai-getting-started.mdx
@@ -1,0 +1,175 @@
+---
+title: Getting Started
+step: Install LyteNyte Grid's agent skills and generate your first production-ready grid component from a natural language prompt.
+description: >
+  Install LyteNyte Grid's agent skills and generate your first production-ready grid component
+  from a natural language prompt in minutes.
+---
+
+This guide walks you through installing the agent skills and generating your first grid with an
+AI coding agent. The whole process takes under five minutes.
+
+## Prerequisites
+
+Before you start, make sure you have:
+
+- **Node.js 18+** — required to run the `skills` CLI via `npx`
+- **A supported AI agent** — Cursor, Kiro, Claude Code, Codex, GitHub Copilot, or any agent
+  that reads from `.agents/skills/`
+- **LyteNyte Grid installed** — Core or PRO in your React project
+
+If you do not have LyteNyte Grid installed yet, see the [Installation guide](/docs/intro-installation).
+
+## Installing the Skills
+
+Run the following command from your project root to install all available skills:
+
+```sh
+npx skills add https://github.com/1771-technologies/lytenyte/tree/main/.agents/skills
+```
+
+This installs the skills into `.agents/skills/` in your project. Supported agents pick them up
+automatically — no additional configuration required.
+
+### Selective Installation
+
+If you only need specific skills, pass `--skill` flags:
+
+```sh
+npx skills add https://github.com/1771-technologies/lytenyte/tree/main/.agents/skills \
+  --skill generate_grid_from_intent \
+  --skill generate_grid_code \
+  --skill design_grid_structure
+```
+
+:::info
+
+The `skills` CLI supports 40+ agents. Run `npx skills add --help` to see all options,
+or visit [skills.sh](https://skills.sh/) to browse the full agent compatibility list.
+
+:::
+
+## Verifying the Installation
+
+After installation, your project should have a `.agents/skills/` directory:
+
+```
+your-project/
+└── .agents/
+    └── skills/
+        ├── generate_grid_from_intent/
+        │   └── SKILL.md
+        ├── design_grid_structure/
+        │   └── SKILL.md
+        ├── configure_grid_features/
+        │   └── SKILL.md
+        └── ... (12 more skills)
+```
+
+Your agent will read these files automatically when you start a new conversation.
+
+## Required Inputs
+
+When prompting your agent to generate a grid, you can provide any combination of:
+
+| Input | Description | Example |
+|---|---|---|
+| Natural language | Plain description of what you want | "A sales dashboard with region, product, revenue" |
+| Dataset sample | A TypeScript type or sample JSON rows | `type Row = { id: string; revenue: number }` |
+| Partial config | An existing column array or component | Paste your current `columns` array |
+| Feature list | Specific features to include | "with grouping, CSV export, and inline editing" |
+
+The more context you provide, the more accurate the output. A dataset type or sample is especially
+helpful for correct column type inference.
+
+## Minimal Usage Flow
+
+Here is the simplest possible prompt to get a working grid:
+
+> "Create a grid for this data: `[{ id: 1, name: 'Alice', score: 95 }, { id: 2, name: 'Bob', score: 82 }]`"
+
+The agent will:
+
+1. Infer column types (`name` → text, `score` → number)
+2. Scaffold a `GridSpec` interface
+3. Build the `columns` array with correct types
+4. Wire `useClientDataSource` with `rowId: (r) => r.id`
+5. Add the required CSS imports
+6. Output a complete, runnable React component
+
+## Output Structure
+
+The agent produces a single React component file. A typical output looks like this:
+
+```tsx
+import { Grid, useClientDataSource } from "@1771technologies/lytenyte-core";
+import type { Grid as GridTypes } from "@1771technologies/lytenyte-core";
+import "@1771technologies/lytenyte-core/grid.css";
+import "@1771technologies/lytenyte-core/light-dark.css";
+
+interface RowData {
+  id: number;
+  name: string;
+  score: number;
+}
+
+type Spec = GridTypes.GridSpec<RowData>;
+
+const columns: GridTypes.Column<Spec>[] = [
+  { columnId: "name", headerName: "Name", field: "name", width: 200 },
+  { columnId: "score", headerName: "Score", field: "score", type: "number", width: 120 },
+];
+
+export function ScoreGrid({ data }: { data: RowData[] }) {
+  const source = useClientDataSource<Spec>({ rows: data, rowId: (r) => r.id });
+
+  return (
+    <div style={{ height: 400 }}>
+      <Grid rowSource={source} columns={columns} />
+    </div>
+  );
+}
+```
+
+Every generated component includes:
+
+- Correct package imports (Core or PRO based on features used)
+- Required CSS imports (`grid.css` + a theme)
+- A typed `GridSpec` interface
+- Columns defined outside the component body
+- A `rowId` function on the data source
+- `import type` for type-only imports
+
+## Integration Points
+
+The generated component is a standard React component. Drop it into your app like any other:
+
+```tsx
+import { ScoreGrid } from "./ScoreGrid";
+
+export default function Dashboard() {
+  return <ScoreGrid data={myData} />;
+}
+```
+
+For server-side data, the agent generates a component that accepts a `rowSource` prop or
+wires `useServerDataSource` with your load callback. See the [Examples](/docs/ai-examples) page
+for server-side patterns.
+
+## Quick Validation
+
+After the agent generates a component, check these things before running it:
+
+- [ ] CSS imports are present (`grid.css` + a theme file)
+- [ ] `rowId` is defined on the data source call
+- [ ] `columns` is defined outside the component body
+- [ ] If using PRO features, `activateLicense()` is called before the component renders
+- [ ] The container has an explicit height (the grid needs a bounded height to virtualize rows)
+
+The `validate_and_refine_config` skill runs these checks automatically as part of the generation
+pipeline, so most issues are caught before the code is emitted.
+
+## Next Steps
+
+::next[/docs/ai-agent-skills]
+::next[/docs/ai-examples]

--- a/documentation-v2/docs/(ai-agents)/ai-overview.mdx
+++ b/documentation-v2/docs/(ai-agents)/ai-overview.mdx
@@ -1,0 +1,128 @@
+---
+title: Overview
+step: Understand how LyteNyte Grid integrates with AI coding agents to generate production-ready grid implementations from natural language.
+description: >
+  LyteNyte Grid ships with a set of agent skills that give AI coding agents deep knowledge of the
+  grid's APIs, patterns, and best practices — enabling them to generate complete, production-ready
+  grid implementations from a natural language prompt.
+---
+
+LyteNyte Grid is built to work natively with AI coding agents. Instead of writing boilerplate
+column definitions, wiring data sources, and configuring features by hand, you describe what you
+want and your agent builds it — correctly, on the first try.
+
+## What AI Integration Means for the Grid
+
+Traditional grid development requires you to know the right APIs, the right import paths, the
+correct TypeScript generics, and the exact sequence of configuration steps. That knowledge takes
+time to acquire and is easy to get wrong.
+
+LyteNyte Grid's AI integration packages that knowledge into **agent skills** — reusable instruction
+sets that give your agent everything it needs to generate correct, idiomatic grid code without
+hallucinating APIs or missing required imports.
+
+## The Agent-Based Approach
+
+Rather than a single monolithic prompt, LyteNyte Grid uses a **skill-based agent architecture**.
+Each skill is a focused instruction set that covers one area of the grid. When you give your agent
+a task, it selects and chains the relevant skills to produce a complete implementation.
+
+This approach has three key advantages:
+
+- **Accuracy** — each skill encodes the exact APIs, types, and patterns for its domain
+- **Composability** — skills combine naturally for complex grids without conflicting instructions
+- **Maintainability** — skills are versioned alongside the grid and stay up to date
+
+## Key Capabilities Enabled by AI
+
+| Capability | What the agent can do |
+|---|---|
+| Grid scaffolding | Generate a complete typed grid from a dataset or description |
+| Column design | Infer column types, field paths, and `GridSpec` generics |
+| Feature wiring | Configure sorting, filtering, grouping, aggregation, and row selection |
+| Data source selection | Pick and wire the right data source hook for the use case |
+| Cell renderers | Generate custom renderers for badges, dates, currency, and more |
+| Theming | Apply CSS imports, select themes, configure custom properties |
+| PRO features | Server-side loading, pivoting, tree data, expression filters |
+| Export | Wire CSV, Excel, Parquet, and Arrow export via the grid API |
+| Validation | Type-check the config and fix common mistakes before output |
+
+## How AI Changes Grid Development
+
+Without AI skills, building a grid typically looks like this:
+
+1. Read the docs to find the right API
+2. Write column definitions manually
+3. Wire the data source hook
+4. Configure each feature separately
+5. Debug TypeScript errors
+6. Repeat for every new grid
+
+With AI skills installed, the workflow becomes:
+
+1. Describe what you want in plain language
+2. Review and adjust the generated component
+
+The agent handles the lookup, the boilerplate, and the type wiring. You focus on the product.
+
+## Supported Use Cases
+
+The skills cover the full range of LyteNyte Grid use cases:
+
+- **Client-side grids** — flat data, sorting, filtering, grouping, aggregation
+- **Server-side grids** — paginated or infinite loading, server filtering and sorting
+- **Tree data** — hierarchical rows with expand/collapse
+- **Editable grids** — inline editing, validation, bulk edits, linked edits
+- **Real-time grids** — WebSocket/SSE updates, diff patching, cell flash
+- **Pivot tables** — row and column pivots, measures, totals
+- **Export workflows** — CSV, Excel, Parquet, Arrow, clipboard
+- **Secured grids** — column visibility by role, data masking, conditional editability
+
+## System Architecture
+
+The AI integration follows a layered flow:
+
+```
+User prompt / dataset
+        ↓
+generate_grid_from_intent   ← parses intent, maps to features, delegates
+        ↓
+design_grid_structure       ← columns, GridSpec, rowId, data source
+configure_grid_features     ← sorting, filtering, grouping, selection
+apply_ui_customization      ← renderers, styling, layout
+setup_data_integration      ← correct data source hook
+        ↓
+[optional skills]
+setup_cell_editing          ← editors, validation, bulk edits
+apply_business_logic        ← aggregations, KPIs, expressions, pivots
+enhance_grid_with_extensions← export, clipboard, API extensions
+configure_theming           ← CSS, themes, Tailwind, CSS Modules
+optimize_grid_performance   ← row height, buffering, React Compiler
+enable_realtime_updates     ← WebSocket/SSE, diff patching, cell flash
+apply_security_controls     ← role-based visibility, masking
+        ↓
+validate_and_refine_config  ← type-check, fix mistakes, enforce rules
+        ↓
+generate_grid_code          ← final React component with all imports
+```
+
+For targeted requests ("add Excel export", "switch to server-side loading"), the agent invokes
+only the relevant skill directly — it does not run the full pipeline every time.
+
+## Terminology
+
+| Term | Meaning |
+|---|---|
+| **Agent skill** | A focused instruction set that gives an AI agent deep knowledge of one area of the grid |
+| **GridSpec** | The TypeScript generic interface that types row data, column extensions, and API extensions |
+| **Data source** | A hook (`useClientDataSource`, `useServerDataSource`, etc.) that provides rows to the grid |
+| **Cell renderer** | A React component that renders the content of a single cell |
+| **Column extension** | Extra typed properties added to column definitions via `GridSpec` |
+| **API extension** | Custom imperative methods added to the grid API via `apiExtension` |
+| **Skill chain** | A sequence of skills invoked in order to build a complete grid from scratch |
+| **Targeted invocation** | Calling a single skill directly for a specific, scoped change |
+
+## Next Steps
+
+::next[/docs/ai-getting-started]
+::next[/docs/ai-agent-skills]

--- a/documentation-v2/docs/(ai-agents)/meta.json
+++ b/documentation-v2/docs/(ai-agents)/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "AI Agents",
+  "pages": [
+    "ai-overview",
+    "ai-getting-started",
+    "ai-agent-skills",
+    "ai-examples"
+  ],
+  "defaultOpen": true
+}

--- a/documentation-v2/docs/meta.json
+++ b/documentation-v2/docs/meta.json
@@ -18,7 +18,8 @@
     "(tree-data)",
     "(components)",
     "(export)",
-    "(misc)"
+    "(misc)",
+    "(ai-agents)"
   ],
   "root": true
 }


### PR DESCRIPTION
## What
Adds the AI Agents section to the documentation site and the agent
skills that power AI-driven grid generation.

## Changes

**Agent Skills** (`.agents/skills/`)
15 focused instruction sets covering the full generation pipeline —
intent parsing, column structure, feature wiring, UI customization,
data integration, server-side loading, cell editing, business logic,
export/extensions, theming, performance, realtime updates, security
controls, validation, and final code output.

**Documentation** (`documentation-v2/docs/(ai-agents)/`)
Four new pages added to the sidebar under "AI Agents":
- Overview — concept, architecture flow, terminology
- Getting Started — install, minimal usage, output structure
- Agent Skills — full reference for all 15 skills
- Examples — real prompts mapped to generated grid code

**Bug fix** (`packages-auxiliary/lytenyte-doc/`)
Fixed `ERR_UNKNOWN_FILE_EXTENSION` on dev server start caused by
`ec.config.mjs` trying to load a `.ts` file via Node's native ESM
loader. Changed the `/code` export to point to `code.mjs`.

## Testing
- Dev server starts without errors
- All four AI Agents pages render in the sidebar
- `::next[]` links resolve correctly (step field added to all pages)
